### PR TITLE
using redis-sharelatex 0.0.4, 0.0.3 doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.0.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.0.0",
     "request": "~2.33.0",
-    "redis-sharelatex": "0.0.3",
+    "redis-sharelatex": "0.0.4",
     "redis": "~0.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As you can see in https://registry.npmjs.org/redis-sharelatex/ , there is no redis-sharelatex 0.0.3
This is producing an error during grunt install of sharelatex. I don't think it causes any bug though (I don't know why).
