### PR TITLE
Use packs to reduce docHistory index size

### DIFF
--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -353,6 +353,8 @@ module.exports = MongoManager =
 		db.docHistory.ensureIndex { doc_id: 1, v: 1 }, { background: true }
 		# For finding all updates that affect a project (getProjectUpdates meta.end_ts < before
 		db.docHistory.ensureIndex { project_id: 1, "meta.end_ts": 1 }, { background: true }
+		# For finding all packs that affect a project (use a sparse index so only packs are included)
+		db.docHistory.ensureIndex { project_id: 1, "pack.0.meta.end_ts": 1, "meta.end_ts": 1}	, { background: true, sparse: true }
 		# For finding updates that don't yet have a project_id and need it inserting
 		db.docHistory.ensureIndex { doc_id: 1, project_id: 1 }, { background: true }
 		# For finding project meta-data

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -10,7 +10,10 @@ module.exports = MongoManager =
 			.limit(1)
 			.toArray (error, compressedUpdates) ->
 				return callback(error) if error?
-				return callback null, null if compressedUpdates[0]?.pack? # cannot pop from a pack
+				if compressedUpdates[0]?.pack?
+					# cannot pop from a pack, throw error
+					error = new Error("last compressed update is a pack")
+					return callback error, null
 				return callback null, compressedUpdates[0] or null
 
 	deleteCompressedUpdate: (id, callback = (error) ->) ->

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -1,5 +1,5 @@
 {db, ObjectId} = require "./mongojs"
-MongoPackManager = require "./MongoPackManager"
+PackManager = require "./PackManager"
 async = require "async"
 _ = require "underscore"
 
@@ -65,7 +65,7 @@ module.exports = MongoManager =
 			query["v"] ||= {}
 			query["v"]["$lte"] = options.to
 			
-		MongoPackManager.findDocResults(db.docHistory, query, options.limit, callback)	
+		PackManager.findDocResults(db.docHistory, query, options.limit, callback)	
 
 	getProjectUpdates: (project_id, options = {}, callback = (error, updates) ->) ->
 		query = 
@@ -74,7 +74,7 @@ module.exports = MongoManager =
 		if options.before?
 			query["meta.end_ts"] = { $lt: options.before }
 
-		MongoPackManager.findProjectResults(db.docHistory, query, options.limit, callback)	
+		PackManager.findProjectResults(db.docHistory, query, options.limit, callback)	
 
 	backportProjectId: (project_id, doc_id, callback = (error) ->) ->
 		db.docHistory.update {

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -11,6 +11,7 @@ module.exports = MongoManager =
 			.limit(1)
 			.toArray (error, compressedUpdates) ->
 				return callback(error) if error?
+				return callback null, null if compressedUpdates[0]?.pack? # cannot pop from a pack
 				return callback null, compressedUpdates[0] or null
 
 	# only used in this module

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -1,4 +1,5 @@
 {db, ObjectId} = require "./mongojs"
+MongoPackManager = require "./MongoPackManager"
 async = require "async"
 _ = require "underscore"
 
@@ -54,253 +55,6 @@ module.exports = MongoManager =
 		# may need to roll over a pack here if we are inserting packs
 		db.docHistory.insert update, callback
 
-	# The following function implements a method like a mongo find, but
-	# which expands any documents containing a 'pack' field into
-	# multiple values
-	#
-	#  e.g.  a single update looks like
-	#
-	#   {
-	#     "doc_id" : 549dae9e0a2a615c0c7f0c98,
-	#     "project_id" : 549dae9c0a2a615c0c7f0c8c,
-	#     "op" : [ {"p" : 6981,	"d" : "?"	} ],
-	#     "meta" : {	"user_id" : 52933..., "start_ts" : 1422310693931,	"end_ts" : 1422310693931 },
-	#     "v" : 17082
-	#   }
-	#
-	#  and a pack looks like this
-	#
-	#   {
-	#     "doc_id" : 549dae9e0a2a615c0c7f0c98,
-	#     "project_id" : 549dae9c0a2a615c0c7f0c8c,
-	#     "pack" : [ D1, D2, D3, ....],
-	#     "meta" : {	"user_id" : 52933..., "start_ts" : 1422310693931,	"end_ts" : 1422310693931 },
-	#     "v" : 17082
-	#   }
-	#
-	#  where D1, D2, D3, .... are single updates stripped of their
-	#  doc_id and project_id fields (which are the same for all the
-	#  updates in the pack).  The meta and v fields of the pack itself
-	#  are those of the first entry in the pack D1 (this makes it
-	#  possible to treat packs and single updates in the same way).
-
-
-	_findDocResults: (query, limit, callback) ->
-		# query - the mongo query selector, includes both the doc_id/project_id and
-		# the range on v
-		# limit - the mongo limit, we need to apply it after unpacking any
-		# packs
-
-		sort = {}
-		sort['v'] = -1;
-		cursor = db.docHistory
-			.find( query )
-			.sort( sort )
-		# if we have packs, we will trim the results more later after expanding them
-		if limit?
-			cursor.limit(limit)
-
-		# take the part of the query which selects the range over the parameter
-		rangeQuery = query['v']
-
-		# helper function to check if an item from a pack is inside the
-		# desired range
-		filterFn = (item) ->
-			return false if rangeQuery?['$gte']? && item['v'] < rangeQuery['$gte']
-			return false if rangeQuery?['$lte']? && item['v'] > rangeQuery['$lte']
-			return false if rangeQuery?['$lt']? && item['v'] >= rangeQuery['$lt']
-			return false if rangeQuery?['$gt']? && item['v'] <= rangeQuery['$gt']
-			return true
-
-		# create a query which can be used to select the entries BEFORE
-		# the range because we sometimes need to find extra ones (when the
-		# boundary falls in the middle of a pack)
-		extraQuery = _.clone(query)
-		# The pack uses its first entry for its metadata and v, so the
-		# only queries where we might not get all the packs are those for
-		# $gt and $gte (i.e. we need to find packs which start before our
-		# range but end in it)
-		if rangeQuery?['$gte']?
-			extraQuery['v'] = {'$lt' : rangeQuery['$gte']}
-		else if rangeQuery?['$gt']
-			extraQuery['v'] = {'$lte' : rangeQuery['$gt']}
-		else
-			delete extraQuery['v']
-
-		needMore = false  # keep track of whether we need to load more data
-		updates = [] # used to accumulate the set of results
-		cursor.toArray (err, result) ->
-			unpackedSet = MongoManager._unpackResults(result)
-			updates = MongoManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
-			# check if we need to retrieve more data, because there is a
-			# pack that crosses into our range
-			last = if unpackedSet.length then unpackedSet[unpackedSet.length-1] else null
-			if limit? && updates.length == limit
-				needMore = false
-			else if extraQuery['v']? && last? && filterFn(last)
-				needMore = true
-			else if extraQuery['v']? && updates.length == 0
-				needMore = true
-			if needMore
-				# we do need an extra result set
-				extra = db.docHistory
-					.find(extraQuery)
-					.sort(sort)
-					.limit(1)
-				extra.toArray (err, result2) ->
-					if err?
-						return callback err, updates
-					else
-						extraSet = MongoManager._unpackResults(result2)
-						updates = MongoManager._filterAndLimit(updates, extraSet, filterFn, limit)
-						callback err, updates
-				return
-			if err?
-				callback err, result
-			else
-				callback err, updates
-
-	_findProjectResults: (query, limit, callback) ->
-		# query - the mongo query selector, includes both the doc_id/project_id and
-		# the range on v or meta.end_ts
-		# limit - the mongo limit, we need to apply it after unpacking any
-		# packs
-
-		sort = {}
-		sort['meta.end_ts'] = -1;
-
-		projection = {"op":false, "pack.op": false}
-		cursor = db.docHistory
-			.find( query, projection ) # no need to return the op only need version info
-			.sort( sort )
-		# if we have packs, we will trim the results more later after expanding them
-		if limit?
-			cursor.limit(limit)
-
-		# take the part of the query which selects the range over the parameter
-		before = query['meta.end_ts']?['$lt']  # may be null
-
-		updates = [] # used to accumulate the set of results
-
-		cursor.toArray (err, result) ->
-			if err?
-				return callback err, result
-			if result.length == 0 && not before?  # no results and no time range specified
-				return callback err, result
-
-			unpackedSet = MongoManager._unpackResults(result)
-			if limit?
-				unpackedSet = unpackedSet.slice(0, limit)
-			# find the end time of the last result, we will take all the
-			# results up to this, and then all the changes at that time
-			# (without imposing a limit) and any overlapping packs
-			cutoff = if unpackedSet.length then unpackedSet[unpackedSet.length-1].meta.end_ts else null
-			console.log 'before is', before
-			console.log 'cutoff is', cutoff
-			console.log 'limit  is', limit
-
-			filterFn = (item) ->
-				ts = item?.meta?.end_ts
-				console.log 'checking', ts, before, cutoff
-				return false if before? && ts >= before
-				return false if cutoff? && ts < cutoff
-				return true
-
-			updates = MongoManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
-			console.log 'initial updates are', updates
-
-			# get all elements on the lower bound (cutoff)
-			tailQuery = _.clone(query)
-			tailQuery['meta.end_ts'] = cutoff
-			tail = db.docHistory
-				.find(tailQuery, projection)
-				.sort(sort)
-
-			console.log 'tailQuery is', tailQuery
-
-			# now find any packs that overlap with the time window
-			overlapQuery = _.clone(query)
-			if before? && cutoff?
-				overlapQuery['meta.end_ts'] = {"$gte": before}
-				overlapQuery['pack.0.meta.end_ts'] = {"$lte": before }
-			else if before? && not cutoff?
-				overlapQuery['meta.end_ts'] = {"$gte": before}
-				overlapQuery['pack.0.meta.end_ts'] = {"$lte": before }
-			else if not before? && cutoff?
-				overlapQuery['meta.end_ts'] = {"$gte": cutoff}
-				overlapQuery['pack.0.meta.end_ts'] = {"$gte": 0 }
-			else if not before? && not cutoff?
-				overlapQuery['meta.end_ts'] = {"$gte": 0 }
-				overlapQuery['pack.0.meta.end_ts'] = {"$gte": 0 }
-			overlap = db.docHistory
-				.find(overlapQuery, projection)
-				.sort(sort)
-
-			console.log 'overlapQuery is', overlapQuery
-
-			# we don't specify a limit here, as there could be any number of overlaps
-			# NB. need to catch items in original query and followup query for duplicates
-
-			applyAndUpdate = (result) ->
-				extraSet = MongoManager._unpackResults(result)
-				# note: final argument is null, no limit applied because we
-				# need all the updates at the final time to avoid breaking
-				# the changeset into parts
-				updates = MongoManager._filterAndLimit(updates, extraSet, filterFn, null)
-				console.log 'extra updates after filterandlimit', updates
-				# remove duplicates
-				seen = {}
-				updates = updates.filter (item) ->
-					key = item.doc_id + ' ' + item.v
-					console.log 'key is', key
-					if seen[key]
-						return false
-					else
-						seen[key] = true
-						return true
-				console.log 'extra updates are', updates
-
-			tail.toArray (err, result2) ->
-				if err?
-					return callback err, updates
-				else
-					applyAndUpdate result2
-					overlap.toArray (err, result3) ->
-						if err?
-							return callback err, updates
-						else
-							applyAndUpdate result3
-							callback err, updates
-
-	_unpackResults: (updates) ->
-		#	iterate over the updates, if there's a pack, expand it into ops and
-		# insert it into the array at that point
-		result = []
-		updates.forEach (item) ->
-			if item.pack?
-				all = MongoManager._explodePackToOps item
-				result = result.concat all
-			else
-				result.push item
-		return result
-
-	_explodePackToOps: (packObj) ->
-		# convert a pack into an array of ops
-		doc_id = packObj.doc_id
-		project_id = packObj.project_id
-		result = packObj.pack.map (item) ->
-			item.doc_id = doc_id
-			item.project_id = project_id
-			item
-		return result.reverse()
-
-	_filterAndLimit: (results, extra, filterFn, limit) ->
-		# update results with extra docs, after filtering and limiting
-		filtered = extra.filter(filterFn)
-		newResults = results.concat filtered
-		newResults.slice(0, limit) if limit?
-		return newResults
-
 	getDocUpdates:(doc_id, options = {}, callback = (error, updates) ->) ->
 		query = 
 			doc_id: ObjectId(doc_id.toString())
@@ -311,7 +65,7 @@ module.exports = MongoManager =
 			query["v"] ||= {}
 			query["v"]["$lte"] = options.to
 			
-		MongoManager._findDocResults(query, options.limit, callback)	
+		MongoPackManager.findDocResults(db.docHistory, query, options.limit, callback)	
 
 	getProjectUpdates: (project_id, options = {}, callback = (error, updates) ->) ->
 		query = 
@@ -320,7 +74,7 @@ module.exports = MongoManager =
 		if options.before?
 			query["meta.end_ts"] = { $lt: options.before }
 
-		MongoManager._findProjectResults(query, options.limit, callback)	
+		MongoPackManager.findProjectResults(db.docHistory, query, options.limit, callback)	
 
 	backportProjectId: (project_id, doc_id, callback = (error) ->) ->
 		db.docHistory.update {

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -1,7 +1,9 @@
 {db, ObjectId} = require "./mongojs"
 async = require "async"
+_ = require "underscore"
 
 module.exports = MongoManager =
+	# only used in this module
 	getLastCompressedUpdate: (doc_id, callback = (error, update) ->) ->
 		db.docHistory
 			.find(doc_id: ObjectId(doc_id.toString()))
@@ -11,9 +13,11 @@ module.exports = MongoManager =
 				return callback(error) if error?
 				return callback null, compressedUpdates[0] or null
 
+	# only used in this module
 	deleteCompressedUpdate: (id, callback = (error) ->) ->
 		db.docHistory.remove({ _id: ObjectId(id.toString()) }, callback)
 
+	# used in UpdatesManager
 	popLastCompressedUpdate: (doc_id, callback = (error, update) ->) ->
 		MongoManager.getLastCompressedUpdate doc_id, (error, update) ->
 			return callback(error) if error?
@@ -24,6 +28,7 @@ module.exports = MongoManager =
 			else
 				callback null, null
 
+	# used in UpdatesManager
 	insertCompressedUpdates: (project_id, doc_id, updates, permanent, callback = (error) ->) ->
 		jobs = []
 		for update in updates
@@ -45,8 +50,78 @@ module.exports = MongoManager =
 			hours = 60 * minutes
 			days = 24 * hours
 			update.expiresAt = new Date(Date.now() + 7 * days)
+		# may need to roll over a pack here if we are inserting packs
 		db.docHistory.insert update, callback
 
+	_findResults: (param, query, limit, callback) ->
+		sort = {}
+		sort[param] = -1;
+		cursor = db.docHistory
+			.find( query )
+			.sort( sort )
+
+		if limit?
+			cursor.limit(limit)
+
+		rangeQuery = query[param]
+		extraQuery = _.clone(query)
+		if rangeQuery?['$gte']?
+			extraQuery[param] = {'$lt' : rangeQuery['$gte']}
+		else if rangeQuery?['$gt']
+			extraQuery[param] = {'$lte' : rangeQuery['$gt']}
+
+		filterFn = (item) ->
+			#console.log 'filter', item, rangeQuery
+			return false if rangeQuery?['$gte']? && item[param] < rangeQuery['$gte']
+			return false if rangeQuery?['$lte']? && item[param] > rangeQuery['$lte']
+			return false if rangeQuery?['$lt']? && item[param] >= rangeQuery['$lt']
+			return false if rangeQuery?['$gt']? && item[param] <= rangeQuery['$gt']
+			#console.log 'accepted'
+			return true
+
+		# need to support limit here
+			
+		cursor.toArray (err, updates) ->
+			console.log 'query=', query, 'UPDATES=', updates
+			all = MongoManager._unpackResults(updates).filter(filterFn)
+			if all.length == 0 
+				# need an extra result set
+				console.log 'extraQuery', extraQuery
+				extra = db.docHistory
+					.find(extraQuery)
+					.sort(sort)
+					.limit(1)
+				extra.toArray (err, updates2) ->
+					all2 = MongoManager._unpackResults(updates2).filter(filterFn)
+					console.log 'got extra', all2
+					callback err, all2
+				return
+			if err?
+				callback err, updates
+			else
+				callback err, all
+
+	_unpackResults: (updates) ->
+		result = []
+		# iterate over the updates
+		# if it's a pack, expand it into ops and insert it into the array at that point
+		updates.forEach (item) ->
+			if item.pack?
+				all = MongoManager._explodePackToOps item
+				result = result.concat all
+			else
+				result.push item
+		return result
+
+	_explodePackToOps: (packObj) ->
+		doc_id = packObj.doc_id
+		project_id = packObj.project_id
+		result = packObj.pack.map (item) ->
+			item.doc_id = doc_id
+			item.project_id = project_id
+			item
+		return result.reverse()
+		
 	getDocUpdates:(doc_id, options = {}, callback = (error, updates) ->) ->
 		query = 
 			doc_id: ObjectId(doc_id.toString())
@@ -57,14 +132,7 @@ module.exports = MongoManager =
 			query["v"] ||= {}
 			query["v"]["$lte"] = options.to
 			
-		cursor = db.docHistory
-			.find( query )
-			.sort( v: -1 )
-
-		if options.limit?
-			cursor.limit(options.limit)
-
-		cursor.toArray callback
+		MongoManager._findResults('v', query, options.limit, callback)	
 
 	getProjectUpdates: (project_id, options = {}, callback = (error, updates) ->) ->
 		query = 
@@ -73,14 +141,7 @@ module.exports = MongoManager =
 		if options.before?
 			query["meta.end_ts"] = { $lt: options.before }
 
-		cursor = db.docHistory
-			.find( query )
-			.sort( "meta.end_ts": -1 )
-
-		if options.limit?
-			cursor.limit(options.limit)
-
-		cursor.toArray callback
+		MongoManager._findResults('meta.end_ts', query, options.limit, callback)	
 
 	backportProjectId: (project_id, doc_id, callback = (error) ->) ->
 		db.docHistory.update {
@@ -109,9 +170,9 @@ module.exports = MongoManager =
 		}, callback
 
 	ensureIndices: () ->
-		# For finding all updates that go into a diff for a doc
+		# For finding all updates that go into a diff for a doc  (getLastCompressedUpdate, getDocUpdates v > from && v < to)
 		db.docHistory.ensureIndex { doc_id: 1, v: 1 }, { background: true }
-		# For finding all updates that affect a project
+		# For finding all updates that affect a project (getProjectUpdates meta.end_ts < before
 		db.docHistory.ensureIndex { project_id: 1, "meta.end_ts": 1 }, { background: true }
 		# For finding updates that don't yet have a project_id and need it inserting
 		db.docHistory.ensureIndex { doc_id: 1, project_id: 1 }, { background: true }

--- a/app/coffee/MongoPackManager.coffee
+++ b/app/coffee/MongoPackManager.coffee
@@ -1,0 +1,250 @@
+async = require "async"
+_ = require "underscore"
+
+module.exports = MongoPackManager =
+	# The following functions implement methods like a mongo find, but
+	# expands any documents containing a 'pack' field into multiple
+	# values
+	#
+	#  e.g.  a single update looks like
+	#
+	#   {
+	#     "doc_id" : 549dae9e0a2a615c0c7f0c98,
+	#     "project_id" : 549dae9c0a2a615c0c7f0c8c,
+	#     "op" : [ {"p" : 6981,	"d" : "?"	} ],
+	#     "meta" : {	"user_id" : 52933..., "start_ts" : 1422310693931,	"end_ts" : 1422310693931 },
+	#     "v" : 17082
+	#   }
+	#
+	#  and a pack looks like this
+	#
+	#   {
+	#     "doc_id" : 549dae9e0a2a615c0c7f0c98,
+	#     "project_id" : 549dae9c0a2a615c0c7f0c8c,
+	#     "pack" : [ D1, D2, D3, ....],
+	#     "meta" : {	"user_id" : 52933..., "start_ts" : 1422310693931,	"end_ts" : 1422310693931 },
+	#     "v" : 17082
+	#   }
+	#
+	#  where D1, D2, D3, .... are single updates stripped of their
+	#  doc_id and project_id fields (which are the same for all the
+	#  updates in the pack).  The meta and v fields of the pack itself
+	#  are those of the first entry in the pack D1 (this makes it
+	#  possible to treat packs and single updates in the same way).
+
+
+	findDocResults: (collection, query, limit, callback) ->
+		# query - the mongo query selector, includes both the doc_id/project_id and
+		# the range on v
+		# limit - the mongo limit, we need to apply it after unpacking any
+		# packs
+
+		sort = {}
+		sort['v'] = -1;
+		cursor = collection
+			.find( query )
+			.sort( sort )
+		# if we have packs, we will trim the results more later after expanding them
+		if limit?
+			cursor.limit(limit)
+
+		# take the part of the query which selects the range over the parameter
+		rangeQuery = query['v']
+
+		# helper function to check if an item from a pack is inside the
+		# desired range
+		filterFn = (item) ->
+			return false if rangeQuery?['$gte']? && item['v'] < rangeQuery['$gte']
+			return false if rangeQuery?['$lte']? && item['v'] > rangeQuery['$lte']
+			return false if rangeQuery?['$lt']? && item['v'] >= rangeQuery['$lt']
+			return false if rangeQuery?['$gt']? && item['v'] <= rangeQuery['$gt']
+			return true
+
+		# create a query which can be used to select the entries BEFORE
+		# the range because we sometimes need to find extra ones (when the
+		# boundary falls in the middle of a pack)
+		extraQuery = _.clone(query)
+		# The pack uses its first entry for its metadata and v, so the
+		# only queries where we might not get all the packs are those for
+		# $gt and $gte (i.e. we need to find packs which start before our
+		# range but end in it)
+		if rangeQuery?['$gte']?
+			extraQuery['v'] = {'$lt' : rangeQuery['$gte']}
+		else if rangeQuery?['$gt']
+			extraQuery['v'] = {'$lte' : rangeQuery['$gt']}
+		else
+			delete extraQuery['v']
+
+		needMore = false  # keep track of whether we need to load more data
+		updates = [] # used to accumulate the set of results
+		cursor.toArray (err, result) ->
+			unpackedSet = MongoPackManager._unpackResults(result)
+			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
+			# check if we need to retrieve more data, because there is a
+			# pack that crosses into our range
+			last = if unpackedSet.length then unpackedSet[unpackedSet.length-1] else null
+			if limit? && updates.length == limit
+				needMore = false
+			else if extraQuery['v']? && last? && filterFn(last)
+				needMore = true
+			else if extraQuery['v']? && updates.length == 0
+				needMore = true
+			if needMore
+				# we do need an extra result set
+				extra = collection
+					.find(extraQuery)
+					.sort(sort)
+					.limit(1)
+				extra.toArray (err, result2) ->
+					if err?
+						return callback err, updates
+					else
+						extraSet = MongoPackManager._unpackResults(result2)
+						updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, limit)
+						callback err, updates
+				return
+			if err?
+				callback err, result
+			else
+				callback err, updates
+
+	findProjectResults: (collection, query, limit, callback) ->
+		# query - the mongo query selector, includes both the doc_id/project_id and
+		# the range on v or meta.end_ts
+		# limit - the mongo limit, we need to apply it after unpacking any
+		# packs
+
+		sort = {}
+		sort['meta.end_ts'] = -1;
+
+		projection = {"op":false, "pack.op": false}
+		cursor = collection
+			.find( query, projection ) # no need to return the op only need version info
+			.sort( sort )
+		# if we have packs, we will trim the results more later after expanding them
+		if limit?
+			cursor.limit(limit)
+
+		# take the part of the query which selects the range over the parameter
+		before = query['meta.end_ts']?['$lt']  # may be null
+
+		updates = [] # used to accumulate the set of results
+
+		cursor.toArray (err, result) ->
+			if err?
+				return callback err, result
+			if result.length == 0 && not before?  # no results and no time range specified
+				return callback err, result
+
+			unpackedSet = MongoPackManager._unpackResults(result)
+			if limit?
+				unpackedSet = unpackedSet.slice(0, limit)
+			# find the end time of the last result, we will take all the
+			# results up to this, and then all the changes at that time
+			# (without imposing a limit) and any overlapping packs
+			cutoff = if unpackedSet.length then unpackedSet[unpackedSet.length-1].meta.end_ts else null
+			#console.log 'before is', before
+			#console.log 'cutoff is', cutoff
+			#console.log 'limit  is', limit
+
+			filterFn = (item) ->
+				ts = item?.meta?.end_ts
+				#console.log 'checking', ts, before, cutoff
+				return false if before? && ts >= before
+				return false if cutoff? && ts < cutoff
+				return true
+
+			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
+			#console.log 'initial updates are', updates
+
+			# get all elements on the lower bound (cutoff)
+			tailQuery = _.clone(query)
+			tailQuery['meta.end_ts'] = cutoff
+			tail = collection
+				.find(tailQuery, projection)
+				.sort(sort)
+
+			#console.log 'tailQuery is', tailQuery
+
+			# now find any packs that overlap with the time window
+			overlapQuery = _.clone(query)
+			if before? && cutoff?
+				overlapQuery['meta.end_ts'] = {"$gte": before}
+				overlapQuery['pack.0.meta.end_ts'] = {"$lte": before }
+			else if before? && not cutoff?
+				overlapQuery['meta.end_ts'] = {"$gte": before}
+				overlapQuery['pack.0.meta.end_ts'] = {"$lte": before }
+			else if not before? && cutoff?
+				overlapQuery['meta.end_ts'] = {"$gte": cutoff}
+				overlapQuery['pack.0.meta.end_ts'] = {"$gte": 0 }
+			else if not before? && not cutoff?
+				overlapQuery['meta.end_ts'] = {"$gte": 0 }
+				overlapQuery['pack.0.meta.end_ts'] = {"$gte": 0 }
+			overlap = collection
+				.find(overlapQuery, projection)
+				.sort(sort)
+
+			#console.log 'overlapQuery is', overlapQuery
+
+			# we don't specify a limit here, as there could be any number of overlaps
+			# NB. need to catch items in original query and followup query for duplicates
+
+			applyAndUpdate = (result) ->
+				extraSet = MongoPackManager._unpackResults(result)
+				# note: final argument is null, no limit applied because we
+				# need all the updates at the final time to avoid breaking
+				# the changeset into parts
+				updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, null)
+				#console.log 'extra updates after filterandlimit', updates
+				# remove duplicates
+				seen = {}
+				updates = updates.filter (item) ->
+					key = item.doc_id + ' ' + item.v
+					#console.log 'key is', key
+					if seen[key]
+						return false
+					else
+						seen[key] = true
+						return true
+				#console.log 'extra updates are', updates
+
+			tail.toArray (err, result2) ->
+				if err?
+					return callback err, updates
+				else
+					applyAndUpdate result2
+					overlap.toArray (err, result3) ->
+						if err?
+							return callback err, updates
+						else
+							applyAndUpdate result3
+							callback err, updates
+
+	_unpackResults: (updates) ->
+		#	iterate over the updates, if there's a pack, expand it into ops and
+		# insert it into the array at that point
+		result = []
+		updates.forEach (item) ->
+			if item.pack?
+				all = MongoPackManager._explodePackToOps item
+				result = result.concat all
+			else
+				result.push item
+		return result
+
+	_explodePackToOps: (packObj) ->
+		# convert a pack into an array of ops
+		doc_id = packObj.doc_id
+		project_id = packObj.project_id
+		result = packObj.pack.map (item) ->
+			item.doc_id = doc_id
+			item.project_id = project_id
+			item
+		return result.reverse()
+
+	_filterAndLimit: (results, extra, filterFn, limit) ->
+		# update results with extra docs, after filtering and limiting
+		filtered = extra.filter(filterFn)
+		newResults = results.concat filtered
+		newResults.slice(0, limit) if limit?
+		return newResults

--- a/app/coffee/MongoPackManager.coffee
+++ b/app/coffee/MongoPackManager.coffee
@@ -60,6 +60,9 @@ module.exports = MongoPackManager =
 			return false if rangeQuery?['$gt']? && item['v'] <= rangeQuery['$gt']
 			return true
 
+		versionOrder = (a, b) ->
+			b.v - a.v
+
 		# create a query which can be used to select the entries BEFORE
 		# the range because we sometimes need to find extra ones (when the
 		# boundary falls in the middle of a pack)
@@ -97,16 +100,16 @@ module.exports = MongoPackManager =
 					.limit(1)
 				extra.toArray (err, result2) ->
 					if err?
-						return callback err, updates
+						return callback err, updates.sort versionOrder
 					else
 						extraSet = MongoPackManager._unpackResults(result2)
 						updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, limit)
-						callback err, updates
+						callback err, updates.sort versionOrder
 				return
 			if err?
 				callback err, result
 			else
-				callback err, updates
+				callback err, updates.sort versionOrder
 
 	findProjectResults: (collection, query, limit, callback) ->
 		# query - the mongo query selector, includes both the doc_id/project_id and

--- a/app/coffee/MongoPackManager.coffee
+++ b/app/coffee/MongoPackManager.coffee
@@ -158,7 +158,12 @@ module.exports = MongoPackManager =
 				return true
 
 			timeOrder = (a, b) ->
-				b.meta.end_ts - a.meta.end_ts
+				(b.meta.end_ts - a.meta.end_ts) || documentOrder(a, b)
+
+			documentOrder = (a, b) ->
+				x = a.doc_id.valueOf()
+				y = b.doc_id.valueOf()
+				if x > y then 1 else if x < y then -1 else 0
 
 			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
 			#console.log 'initial updates are', updates

--- a/app/coffee/MongoPackManager.coffee
+++ b/app/coffee/MongoPackManager.coffee
@@ -154,6 +154,9 @@ module.exports = MongoPackManager =
 				return false if cutoff? && ts < cutoff
 				return true
 
+			timeOrder = (a, b) ->
+				b.meta.end_ts - a.meta.end_ts
+
 			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
 			#console.log 'initial updates are', updates
 
@@ -210,15 +213,15 @@ module.exports = MongoPackManager =
 
 			tail.toArray (err, result2) ->
 				if err?
-					return callback err, updates
+					return callback err, updates.sort timeOrder
 				else
 					applyAndUpdate result2
 					overlap.toArray (err, result3) ->
 						if err?
-							return callback err, updates
+							return callback err, updates.sort timeOrder
 						else
 							applyAndUpdate result3
-							callback err, updates
+							callback err, updates.sort timeOrder
 
 	_unpackResults: (updates) ->
 		#	iterate over the updates, if there's a pack, expand it into ops and

--- a/app/coffee/MongoPackManager.coffee
+++ b/app/coffee/MongoPackManager.coffee
@@ -202,18 +202,6 @@ module.exports = MongoPackManager =
 				# the changeset into parts
 				updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, null)
 				#console.log 'extra updates after filterandlimit', updates
-				# remove duplicates
-				seen = {}
-				updates = updates.filter (item) ->
-					key = item.doc_id + ' ' + item.v
-					#console.log 'key is', key
-					if seen[key]
-						return false
-					else
-						seen[key] = true
-						return true
-				#console.log 'extra updates are', updates
-
 			tail.toArray (err, result2) ->
 				if err?
 					return callback err, updates.sort timeOrder
@@ -252,5 +240,15 @@ module.exports = MongoPackManager =
 		# update results with extra docs, after filtering and limiting
 		filtered = extra.filter(filterFn)
 		newResults = results.concat filtered
+		# remove duplicates
+		seen = {}
+		newResults = newResults.filter (item) ->
+			key = item.doc_id + ' ' + item.v
+			#console.log 'key is', key
+			if seen[key]
+				return false
+			else
+				seen[key] = true
+			return true
 		newResults.slice(0, limit) if limit?
 		return newResults

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -1,7 +1,7 @@
 async = require "async"
 _ = require "underscore"
 
-module.exports = MongoPackManager =
+module.exports = PackManager =
 	# The following functions implement methods like a mongo find, but
 	# expands any documents containing a 'pack' field into multiple
 	# values
@@ -81,8 +81,8 @@ module.exports = MongoPackManager =
 		needMore = false  # keep track of whether we need to load more data
 		updates = [] # used to accumulate the set of results
 		cursor.toArray (err, result) ->
-			unpackedSet = MongoPackManager._unpackResults(result)
-			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
+			unpackedSet = PackManager._unpackResults(result)
+			updates = PackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
 			# check if we need to retrieve more data, because there is a
 			# pack that crosses into our range
 			last = if unpackedSet.length then unpackedSet[unpackedSet.length-1] else null
@@ -102,8 +102,8 @@ module.exports = MongoPackManager =
 					if err?
 						return callback err, updates.sort versionOrder
 					else
-						extraSet = MongoPackManager._unpackResults(result2)
-						updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, limit)
+						extraSet = PackManager._unpackResults(result2)
+						updates = PackManager._filterAndLimit(updates, extraSet, filterFn, limit)
 						callback err, updates.sort versionOrder
 				return
 			if err?
@@ -139,7 +139,7 @@ module.exports = MongoPackManager =
 			if result.length == 0 && not before?  # no results and no time range specified
 				return callback err, result
 
-			unpackedSet = MongoPackManager._unpackResults(result)
+			unpackedSet = PackManager._unpackResults(result)
 			if limit?
 				unpackedSet = unpackedSet.slice(0, limit)
 			# find the end time of the last result, we will take all the
@@ -165,7 +165,7 @@ module.exports = MongoPackManager =
 				y = b.doc_id.valueOf()
 				if x > y then 1 else if x < y then -1 else 0
 
-			updates = MongoPackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
+			updates = PackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
 			#console.log 'initial updates are', updates
 
 			# get all elements on the lower bound (cutoff)
@@ -201,11 +201,11 @@ module.exports = MongoPackManager =
 			# NB. need to catch items in original query and followup query for duplicates
 
 			applyAndUpdate = (result) ->
-				extraSet = MongoPackManager._unpackResults(result)
+				extraSet = PackManager._unpackResults(result)
 				# note: final argument is null, no limit applied because we
 				# need all the updates at the final time to avoid breaking
 				# the changeset into parts
-				updates = MongoPackManager._filterAndLimit(updates, extraSet, filterFn, null)
+				updates = PackManager._filterAndLimit(updates, extraSet, filterFn, null)
 				#console.log 'extra updates after filterandlimit', updates
 			tail.toArray (err, result2) ->
 				if err?
@@ -225,7 +225,7 @@ module.exports = MongoPackManager =
 		result = []
 		updates.forEach (item) ->
 			if item.pack?
-				all = MongoPackManager._explodePackToOps item
+				all = PackManager._explodePackToOps item
 				result = result.concat all
 			else
 				result.push item

--- a/app/coffee/UpdatesManager.coffee
+++ b/app/coffee/UpdatesManager.coffee
@@ -137,6 +137,10 @@ module.exports = UpdatesManager =
 			#          
 			if updates? and updates.length > 0
 				nextBeforeTimestamp = updates[updates.length - 1].meta.end_ts
+				if nextBeforeTimestamp >= before
+					error = new Error("history order is broken")
+					logger.error err: error, project_id:project_id, nextBeforeTimestamp: nextBeforeTimestamp, before:before, "error in project history"
+					return callback(error)
 			else
 				nextBeforeTimestamp = null
 

--- a/pack.coffee
+++ b/pack.coffee
@@ -1,0 +1,72 @@
+mongojs = require "mongojs"
+async = require "async"
+db = mongojs.connect("localhost/sharelatex", ["docHistory"])
+BSON=db.bson.BSON
+util = require 'util'
+_ = require 'underscore'
+MAX_SIZE = 1024*1024
+MAX_COUNT = 1024
+
+packOps = (doc_id, callback) ->
+	console.log 'packing', doc_id
+	db.docHistory.find({doc_id:mongojs.ObjectId(doc_id),pack:{$exists:false}}).sort {v:1}, (err, docs) ->
+		packs = []
+		top = null
+		if docs.length < 100
+			console.log 'only', docs.length, 'ops, skipping'
+			return
+		docs.forEach (d,i) ->
+			sz = BSON.calculateObjectSize(d)
+			if top?	&& top.pack.length < MAX_COUNT && top.sz + sz < MAX_SIZE
+				top.pack = top.pack.concat {v: d.v, meta: d.meta,  op: d.op, _id: d._id}
+				top.sz += sz
+				top.v_end = d.v
+				top.meta.end_ts = d.meta.end_ts
+				return
+			else
+				# create a new pack
+				top = _.clone(d)
+				top.pack = [ {v: d.v, meta: d.meta,  op: d.op, _id: d._id} ]
+				top.meta = { start_ts: d.meta.start_ts, end_ts: d.meta.end_ts }
+				top.sz = sz
+				delete top.op
+				delete top._id
+				packs.push top
+		# never store the last pack, keep some unpacked ops
+		packs.pop()
+		#
+		if packs.length > docs.length
+			console.log 'not enough compression', packs.length, 'vs', docs.length, 'skipping'
+			return
+
+		console.log 'docs', docs.length, 'packs', packs.length
+		tasks = []
+		for pack, i in packs
+			console.log 'storing pack', i
+			do (pack) ->
+				task = (cb) ->
+					bulk = db.docHistory.initializeOrderedBulkOp();
+					console.log 'insert', pack
+					bulk.insert pack
+					pack.pack.forEach (op) ->
+						console.log 'will remove', op._id
+						bulk.find({_id:op._id}).removeOne()
+					bulk.execute (err, result) ->
+						console.log 'ok?', result.ok, 'nInserted', result.nInserted, 'nRemoved', result.nRemoved
+						cb(err, result)
+				tasks.push task
+
+		async.series tasks, (err, result) ->
+			console.log 'writing packs', err, result.length
+			callback err, result
+
+packOpsTask = (doc_id) ->
+	return (callback) ->
+		packOps doc_id, callback
+
+tasks = (packOpsTask id for id in process.argv.slice(2))
+
+async.series tasks, (err, results) ->
+	console.log 'closing db'
+	#console.log util.inspect(results,{depth:null})
+	db.close()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "async": "~0.2.10",
     "express": "3.3.5",
-    "mongojs": "~0.9.11",
+    "mongojs": "^0.18.1",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.0.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.0.0",
     "request": "~2.33.0",
     "redis-sharelatex": "~0.0.4",
-    "redis": "~0.10.1"
+    "redis": "~0.10.1",
+    "underscore": "~1.7.0"
   },
   "devDependencies": {
     "chai": "~1.9.0",

--- a/test/unit/coffee/MongoManager/MongoManagerTests.coffee
+++ b/test/unit/coffee/MongoManager/MongoManagerTests.coffee
@@ -249,14 +249,41 @@ describe "MongoManager", ->
 	describe "getDocUpdates", ->
 		beforeEach ->
 			@results = [
-				{foo: "mock-update", v: 56, meta: {end_ts: 110}},
-				{foo: "mock-update", v: 55, meta: {end_ts: 100}},
-				{foo: "mock-update", v: 42, meta:{end_ts: 90}}
+				{foo: "mock-update", v: 56, meta: {end_ts: 110}, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 55, meta: {end_ts: 100}, doc_id: 100, project_id: 1},
+				{pack: [
+					{foo: "mock-update", v: 54, meta: {end_ts: 99}, doc_id: 300, project_id: 1},
+					{foo: "mock-update", v: 53, meta: {end_ts: 98}, doc_id: 300, project_id: 1},
+					{foo: "mock-update", v: 52, meta: {end_ts: 97}, doc_id: 300, project_id: 1}	]
+					, v: 52, meta: {end_ts: 100}, doc_id: 300, project_id: 1},
+				{pack: [
+					{foo: "mock-update", v: 54, meta: {end_ts: 103}, doc_id: 200, project_id: 1},
+					{foo: "mock-update", v: 53, meta: {end_ts: 101}, doc_id: 200, project_id: 1},
+					{foo: "mock-update", v: 52, meta: {end_ts: 99}, doc_id: 200, project_id: 1}	]
+					, v: 52, meta: {end_ts: 103}, doc_id: 200, project_id: 1},
+				{foo: "mock-update", v: 42, meta:{end_ts: 90}, doc_id: 100, project_id: 1}
 			]
-			@updates = [
-				{foo: "mock-update", v: 55, meta: {end_ts: 100}},
-				{foo: "mock-update", v: 42, meta:{end_ts: 90}}
+			@updates_before = [
+				{foo: "mock-update", v: 55, meta: {end_ts: 100}, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 52, meta: {end_ts: 99}, doc_id: 200, project_id: 1},
+				{foo: "mock-update", v: 54, meta: {end_ts: 99}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 53, meta: {end_ts: 98}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 52, meta: {end_ts: 97}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 42, meta: {end_ts: 90}, doc_id: 100, project_id: 1},
 			]
+			@updates_all = [
+				{foo: "mock-update", v: 56, meta: {end_ts: 110}, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 54, meta: {end_ts: 103}, doc_id: 200, project_id: 1},
+				{foo: "mock-update", v: 53, meta: {end_ts: 101}, doc_id: 200, project_id: 1},
+				{foo: "mock-update", v: 55, meta: {end_ts: 100}, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 52, meta: {end_ts: 99}, doc_id: 200, project_id: 1},
+				{foo: "mock-update", v: 54, meta: {end_ts: 99}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 53, meta: {end_ts: 98}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 52, meta: {end_ts: 97}, doc_id: 300, project_id: 1},
+				{foo: "mock-update", v: 42, meta: {end_ts: 90}, doc_id: 100, project_id: 1}
+			]
+
+
 			@db.docHistory = {}
 			@db.docHistory.find = sinon.stub().returns @db.docHistory
 			@db.docHistory.sort = sinon.stub().returns @db.docHistory
@@ -287,7 +314,7 @@ describe "MongoManager", ->
 					.called.should.equal false
 
 			it "should call the call back with the updates", ->
-				@callback.calledWith(null, @updates).should.equal true
+				@callback.calledWith(null, @updates_before).should.equal true
 
 		describe "without a before timestamp", ->
 			beforeEach ->
@@ -301,7 +328,7 @@ describe "MongoManager", ->
 					.should.equal true
 
 			it "should call the call back with the updates", ->
-				@callback.calledWith(null, @results).should.equal true
+				@callback.calledWith(null, @updates_all).should.equal true
 
 		describe "with a limit", ->
 			beforeEach ->

--- a/test/unit/coffee/MongoManager/MongoManagerTests.coffee
+++ b/test/unit/coffee/MongoManager/MongoManagerTests.coffee
@@ -163,12 +163,26 @@ describe "MongoManager", ->
 
 	describe "getDocUpdates", ->
 		beforeEach ->
-			@updates = ["mock-update"]
+			@results = [
+				{foo: "mock-update", v: 56},
+				{foo: "mock-update", v: 55},
+				{foo: "mock-update", v: 42},
+				{foo: "mock-update", v: 41}
+			]
+			@updates_between = [
+				{foo: "mock-update", v: 55},
+				{foo: "mock-update", v: 42}
+			]
+			@updates_after = [
+				{foo: "mock-update", v: 56},
+				{foo: "mock-update", v: 55},
+				{foo: "mock-update", v: 42}
+			]
 			@db.docHistory = {}
 			@db.docHistory.find = sinon.stub().returns @db.docHistory
 			@db.docHistory.sort = sinon.stub().returns @db.docHistory
 			@db.docHistory.limit = sinon.stub().returns @db.docHistory
-			@db.docHistory.toArray = sinon.stub().callsArgWith(0, null, @updates)
+			@db.docHistory.toArray = sinon.stub().callsArgWith(0, null, @results)
 
 			@from = 42
 			@to   = 55
@@ -190,12 +204,12 @@ describe "MongoManager", ->
 					.calledWith("v": -1)
 					.should.equal true
 
-			it "should not limit the results", ->
-				@db.docHistory.limit
-					.called.should.equal false
+			#it "should not limit the results", ->
+			#	@db.docHistory.limit
+			#		.called.should.equal false
 
-			it "should call the call back with the updates", ->
-				@callback.calledWith(null, @updates).should.equal true
+			it "should call the call back with the results", ->
+				@callback.calledWith(null, @updates_between).should.equal true
 
 		describe "without a to version", ->
 			beforeEach ->
@@ -210,7 +224,7 @@ describe "MongoManager", ->
 					.should.equal true
 
 			it "should call the call back with the updates", ->
-				@callback.calledWith(null, @updates).should.equal true
+				@callback.calledWith(null, @updates_after).should.equal true
 
 		describe "with a limit", ->
 			beforeEach ->
@@ -224,14 +238,22 @@ describe "MongoManager", ->
 
 	describe "getDocUpdates", ->
 		beforeEach ->
-			@updates = ["mock-update"]
+			@results = [
+				{foo: "mock-update", v: 56, meta: {end_ts: 110}},
+				{foo: "mock-update", v: 55, meta: {end_ts: 100}},
+				{foo: "mock-update", v: 42, meta:{end_ts: 90}}
+			]
+			@updates = [
+				{foo: "mock-update", v: 55, meta: {end_ts: 100}},
+				{foo: "mock-update", v: 42, meta:{end_ts: 90}}
+			]
 			@db.docHistory = {}
 			@db.docHistory.find = sinon.stub().returns @db.docHistory
 			@db.docHistory.sort = sinon.stub().returns @db.docHistory
 			@db.docHistory.limit = sinon.stub().returns @db.docHistory
-			@db.docHistory.toArray = sinon.stub().callsArgWith(0, null, @updates)
+			@db.docHistory.toArray = sinon.stub().callsArgWith(0, null, @results)
 
-			@before = Date.now()
+			@before = 101
 
 		describe "with a before timestamp", ->
 			beforeEach ->
@@ -269,7 +291,7 @@ describe "MongoManager", ->
 					.should.equal true
 
 			it "should call the call back with the updates", ->
-				@callback.calledWith(null, @updates).should.equal true
+				@callback.calledWith(null, @results).should.equal true
 
 		describe "with a limit", ->
 			beforeEach ->

--- a/test/unit/coffee/MongoManager/MongoManagerTests.coffee
+++ b/test/unit/coffee/MongoManager/MongoManagerTests.coffee
@@ -164,19 +164,29 @@ describe "MongoManager", ->
 	describe "getDocUpdates", ->
 		beforeEach ->
 			@results = [
-				{foo: "mock-update", v: 56},
-				{foo: "mock-update", v: 55},
-				{foo: "mock-update", v: 42},
-				{foo: "mock-update", v: 41}
+				{foo: "mock-update", v: 56, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 55, doc_id: 100, project_id: 1},
+				{pack: [ {foo: "mock-update", v: 54, doc_id: 100, project_id: 1},
+					{foo: "mock-update", v: 53, doc_id: 100, project_id: 1},
+					{foo: "mock-update", v: 52, doc_id: 100, project_id: 1} ]
+					, v: 52, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 42, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 41, doc_id: 100, project_id: 1}
 			]
 			@updates_between = [
-				{foo: "mock-update", v: 55},
-				{foo: "mock-update", v: 42}
+				{foo: "mock-update", v: 55, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 54, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 53, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 52, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 42, doc_id: 100, project_id: 1}
 			]
 			@updates_after = [
-				{foo: "mock-update", v: 56},
-				{foo: "mock-update", v: 55},
-				{foo: "mock-update", v: 42}
+				{foo: "mock-update", v: 56, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 55, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 54, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 53, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 52, doc_id: 100, project_id: 1},
+				{foo: "mock-update", v: 42, doc_id: 100, project_id: 1}
 			]
 			@db.docHistory = {}
 			@db.docHistory.find = sinon.stub().returns @db.docHistory


### PR DESCRIPTION
Adds a 'pack' type which collects individual updates into a single mongo document, to reduce index size.

