### PR TITLE
Only delete applied ops

### DIFF
--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -6,20 +6,24 @@ rawUpdatesKey = (doc_id) -> "UncompressedHistoryOps:#{doc_id}"
 docsWithHistoryOpsKey = (project_id) -> "DocsWithHistoryOps:#{project_id}"
 
 module.exports = RedisManager =
-	getOldestRawUpdates: (doc_id, batchSize, callback = (error, rawUpdates) ->) ->
-		key = rawUpdatesKey(doc_id)
-		rclient.lrange key, 0, batchSize - 1, (error, jsonUpdates) -> 
-			try
-				rawUpdates = ( JSON.parse(update) for update in jsonUpdates or [] )
-			catch e
-				return callback(e)
-			callback null, rawUpdates
 
-	deleteOldestRawUpdates: (project_id, doc_id, batchSize, callback = (error) ->) ->
+	getOldestDocUpdates: (doc_id, batchSize, callback = (error, jsonUpdates) ->) ->
+		key = rawUpdatesKey(doc_id)
+		rclient.lrange key, 0, batchSize - 1, callback
+
+	expandDocUpdates: (jsonUpdates, callback = (error, rawUpdates) ->) ->
+		try
+			rawUpdates = ( JSON.parse(update) for update in jsonUpdates or [] )
+		catch e
+			return callback(e)
+		callback null, rawUpdates
+
+	deleteAppliedDocUpdates: (project_id, doc_id, docUpdates, callback = (error) ->) ->
 		# It's ok to delete the doc_id from the set here. Even though the list
 		# of updates may not be empty, we will continue to process it until it is.
 		multi = rclient.multi()
-		multi.ltrim rawUpdatesKey(doc_id), batchSize, -1
+		for update in docUpdates or []
+			multi.lrem rawUpdatesKey(doc_id), 0, update
 		multi.srem  docsWithHistoryOpsKey(project_id), doc_id
 		multi.exec (error, results) ->
 			return callback(error) if error?

--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -19,11 +19,12 @@ module.exports = RedisManager =
 		callback null, rawUpdates
 
 	deleteAppliedDocUpdates: (project_id, doc_id, docUpdates, callback = (error) ->) ->
-		# It's ok to delete the doc_id from the set here. Even though the list
-		# of updates may not be empty, we will continue to process it until it is.
 		multi = rclient.multi()
+		# Delete all the updates which have been applied (exact match)
 		for update in docUpdates or []
 			multi.lrem rawUpdatesKey(doc_id), 0, update
+		# It's ok to delete the doc_id from the set here. Even though the list
+		# of updates may not be empty, we will continue to process it until it is.
 		multi.srem  docsWithHistoryOpsKey(project_id), doc_id
 		multi.exec (error, results) ->
 			return callback(error) if error?

--- a/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
+++ b/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
@@ -158,14 +158,15 @@ describe "UpdatesManager", ->
 	describe "processUncompressedUpdates", ->
 		beforeEach ->
 			@UpdatesManager.compressAndSaveRawUpdates = sinon.stub().callsArgWith(4)
-			@RedisManager.deleteOldestRawUpdates = sinon.stub().callsArg(3)
+			@RedisManager.deleteAppliedDocUpdates = sinon.stub().callsArg(3)
 			@MongoManager.backportProjectId = sinon.stub().callsArg(2)
 			@UpdateTrimmer.shouldTrimUpdates = sinon.stub().callsArgWith(1, null, @temporary = "temp mock")
 
 		describe "when there is fewer than one batch to send", ->
 			beforeEach ->
 				@updates = ["mock-update"]
-				@RedisManager.getOldestRawUpdates = sinon.stub().callsArgWith(2, null, @updates)
+				@RedisManager.getOldestDocUpdates = sinon.stub().callsArgWith(2, null, @updates)
+				@RedisManager.expandDocUpdates = sinon.stub().callsArgWith(1, null, @updates)
 				@UpdatesManager.processUncompressedUpdates @project_id, @doc_id, @callback
 
 			it "should check if the updates are temporary", ->
@@ -179,7 +180,7 @@ describe "UpdatesManager", ->
 					.should.equal true
 
 			it "should get the oldest updates", ->
-				@RedisManager.getOldestRawUpdates
+				@RedisManager.getOldestDocUpdates
 					.calledWith(@doc_id, @UpdatesManager.REDIS_READ_BATCH_SIZE)
 					.should.equal true
 
@@ -189,8 +190,8 @@ describe "UpdatesManager", ->
 					.should.equal true
 
 			it "should delete the batch of uncompressed updates that was just processed", ->
-				@RedisManager.deleteOldestRawUpdates
-					.calledWith(@project_id, @doc_id, @updates.length)
+				@RedisManager.deleteAppliedDocUpdates
+					.calledWith(@project_id, @doc_id, @updates)
 					.should.equal true
 
 			it "should call the callback", ->
@@ -201,17 +202,20 @@ describe "UpdatesManager", ->
 				@UpdatesManager.REDIS_READ_BATCH_SIZE = 2
 				@updates = ["mock-update-0", "mock-update-1", "mock-update-2", "mock-update-3", "mock-update-4"]
 				@redisArray = @updates.slice()
-				@RedisManager.getOldestRawUpdates = (doc_id, batchSize, callback = (error, updates) ->) =>
+				@RedisManager.getOldestDocUpdates = (doc_id, batchSize, callback = (error, updates) ->) =>
 					updates = @redisArray.slice(0, batchSize)
 					@redisArray = @redisArray.slice(batchSize)
 					callback null, updates
-				sinon.spy @RedisManager, "getOldestRawUpdates"
+				sinon.spy @RedisManager, "getOldestDocUpdates"
+				@RedisManager.expandDocUpdates = (jsonUpdates, callback) =>
+					callback null, jsonUpdates
+				sinon.spy @RedisManager, "expandDocUpdates"
 				@UpdatesManager.processUncompressedUpdates @project_id, @doc_id, (args...) =>
 					@callback(args...)
 					done()
 
 			it "should get the oldest updates in three batches ", ->
-				@RedisManager.getOldestRawUpdates.callCount.should.equal 3
+				@RedisManager.getOldestDocUpdates.callCount.should.equal 3
 
 			it "should compress and save the updates in batches", ->
 				@UpdatesManager.compressAndSaveRawUpdates
@@ -225,7 +229,7 @@ describe "UpdatesManager", ->
 					.should.equal true
 
 			it "should delete the batches of uncompressed updates", ->
-				@RedisManager.deleteOldestRawUpdates.callCount.should.equal 3
+				@RedisManager.deleteAppliedDocUpdates.callCount.should.equal 3
 
 			it "should call the callback", ->
 				@callback.called.should.equal true


### PR DESCRIPTION
This change makes the queued op deletion more robust in the event of an unexpected lock failure, by explicitly deleting only the ops which have been applied.