### PR TITLE
Archive all data in history

### DIFF
--- a/app/coffee/MongoAWS.coffee
+++ b/app/coffee/MongoAWS.coffee
@@ -19,7 +19,7 @@ module.exports = MongoAWS =
 
 		query = {
 			doc_id: ObjectId(doc_id)
-			v: {$lt: update.v}
+			v: {$lte: update.v}
 			expiresAt: {$exists : false}
 		}
 

--- a/app/coffee/UpdatesManager.coffee
+++ b/app/coffee/UpdatesManager.coffee
@@ -17,17 +17,13 @@ module.exports = UpdatesManager =
 			return callback()
 
 		MongoManager.peekLastCompressedUpdate doc_id, (error, lastCompressedUpdate, lastVersion) ->
-			# lastCompressedUpdate is the most recent update in Mongo.
+			# lastCompressedUpdate is the most recent update in Mongo, and
+			# lastVersion is its sharejs version number.
 			#
-			# The peekLastCompressedUpdate method may pass it back as 'null'
-			# to force the start of a new compressed update, even when there
-			# was a previous compressed update in Mongo.  In this case it
-			# passes back the lastVersion from the update to check
-			# consistency.
-
-			# when lastVersion is not provided, default to lastCompressedUpdate.v
-			lastVersion ?= lastCompressedUpdate?.v
-
+			# The peekLastCompressedUpdate method may pass the update back
+			# as 'null' (for example if the previous compressed update has
+			# been archived).  In this case it can still pass back the
+			# lastVersion from the update to allow us to check consistency.
 			return callback(error) if error?
 
 			# Ensure that raw updates start where lastVersion left off

--- a/test/acceptance/coffee/ArchivingUpdatesTests.coffee
+++ b/test/acceptance/coffee/ArchivingUpdatesTests.coffee
@@ -71,27 +71,27 @@ describe "Archiving updates", ->
 				throw error if error?
 				done()
 
-		it "should remain one doc change", (done) ->
+		it "should remain zero doc change", (done) ->
 			db.docHistory.count { doc_id: ObjectId(@doc_id) }, (error, count) ->
 				throw error if error?
-				count.should.equal 1
+				count.should.equal 0
 				done()
 
-		it "should remained doc marked as inS3", (done) ->
-			db.docHistory.findOne { doc_id: ObjectId(@doc_id) }, (error, doc) ->
+		it "should have docHistoryStats marked as inS3", (done) ->
+			db.docHistoryStats.findOne { doc_id: ObjectId(@doc_id) }, (error, doc) ->
 				throw error if error?
 				doc.inS3.should.equal true
 				done()
 
-		it "should remained doc have last version", (done) ->
-			db.docHistory.findOne { doc_id: ObjectId(@doc_id) }, (error, doc) ->
+		it "should have docHistoryStats with the last version", (done) ->
+			db.docHistoryStats.findOne { doc_id: ObjectId(@doc_id) }, (error, doc) ->
 				throw error if error?
-				doc.v.should.equal 20
+				doc.lastVersion.should.equal 20
 				done()
 
-		it "should store nineteen doc changes in S3", (done) ->
+		it "should store twenty doc changes in S3", (done) ->
 			TrackChangesClient.getS3Doc @project_id, @doc_id, (error, res, doc) =>
-				doc.length.should.equal 19
+				doc.length.should.equal 20
 				done()
 
 	describe "unarchiving a doc's updates", ->
@@ -107,7 +107,8 @@ describe "Archiving updates", ->
 				done()
 
 		it "should remove doc marked as inS3", (done) ->
-			db.docHistory.count { doc_id: ObjectId(@doc_id), inS3 : true }, (error, count) ->
+			db.docHistoryStats.findOne {doc_id: ObjectId(@doc_id)}, (error, doc) ->
 				throw error if error?
-				count.should.equal 0
+				doc.should.not.contain.key('inS3')
+				doc.should.not.contain.key('lastVersion')
 				done()

--- a/test/unit/coffee/DocArchive/DocArchiveManager.coffee
+++ b/test/unit/coffee/DocArchive/DocArchiveManager.coffee
@@ -61,8 +61,8 @@ describe "DocArchiveManager", ->
 		beforeEach ->
 			@update = { _id: ObjectId(), op: "op", meta: "meta", v: "v"}
 			@MongoManager.getDocChangesCount = sinon.stub().callsArg(1)
-			@MongoManager.getArchivedDocChanges = sinon.stub().callsArgWith(1, null, 0)
-			@MongoManager.getLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @update)
+			@MongoManager.getArchivedDocStatus = sinon.stub().callsArgWith(1, null, 0)
+			@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @update, @update.v)
 			@MongoAWS.archiveDocHistory = sinon.stub().callsArg(3)
 			@MongoManager.markDocHistoryAsArchiveInProgress = sinon.stub().callsArg(2)
 			@MongoManager.markDocHistoryAsArchived = sinon.stub().callsArg(2)
@@ -71,7 +71,7 @@ describe "DocArchiveManager", ->
 		it "should run markDocHistoryAsArchived with doc_id and update", ->
 			@MongoManager.markDocHistoryAsArchived
 				.calledWith(
-					@doc_id, @update
+					@doc_id, @update.v
 				)
 				.should.equal true
 		it "should call the callback", ->
@@ -107,7 +107,7 @@ describe "DocArchiveManager", ->
 
 	describe "unArchiveDocChanges", ->
 		beforeEach ->
-			@MongoManager.getArchivedDocChanges = sinon.stub().callsArg(1)
+			@MongoManager.getArchivedDocStatus = sinon.stub().callsArgWith(1, null, {inS3: true})
 			@MongoAWS.unArchiveDocHistory = sinon.stub().callsArg(2)
 			@MongoManager.markDocHistoryAsUnarchived = sinon.stub().callsArg(1)
 			@DocArchiveManager.unArchiveDocChanges @project_id, @doc_id, @callback

--- a/test/unit/coffee/MongoManager/MongoManagerTests.coffee
+++ b/test/unit/coffee/MongoManager/MongoManagerTests.coffee
@@ -57,6 +57,8 @@ describe "MongoManager", ->
 	describe "peekLastCompressedUpdate", ->
 		describe "when there is no last update", ->
 			beforeEach ->
+				@db.docHistoryStats = {}
+				@db.docHistoryStats.findOne = sinon.stub().callsArgWith(2, null, null)
 				@MongoManager.getLastCompressedUpdate = sinon.stub().callsArgWith(1, null, null)
 				@MongoManager.peekLastCompressedUpdate @doc_id, @callback
 
@@ -84,8 +86,10 @@ describe "MongoManager", ->
 
 		describe "when there is a last update in S3", ->
 			beforeEach ->
-				@update = { _id: Object(), v: 12345, inS3: true }
-				@MongoManager.getLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @update)
+				@update = { _id: Object(), v: 12345}
+				@db.docHistoryStats = {}
+				@db.docHistoryStats.findOne = sinon.stub().callsArgWith(2, null, {inS3:true, lastVersion: @update.v})
+				@MongoManager.getLastCompressedUpdate = sinon.stub().callsArgWith(1, null)
 				@MongoManager.peekLastCompressedUpdate @doc_id, @callback
 
 			it "should get the last update", ->

--- a/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
+++ b/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
@@ -69,7 +69,7 @@ describe "UpdatesManager", ->
 				@lastCompressedUpdate = { v: 11, op: "compressed-op-11" }
 				@compressedUpdates = [ { v: 12, op: "compressed-op-11+12" }, { v: 13, op: "compressed-op-12" } ]
 
-				@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @lastCompressedUpdate)
+				@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @lastCompressedUpdate, @lastCompressedUpdate.v)
 				@MongoManager.modifyCompressedUpdate = sinon.stub().callsArg(2)
 				@MongoManager.insertCompressedUpdates = sinon.stub().callsArg(4)
 				@UpdateCompressor.compressRawUpdates = sinon.stub().returns(@compressedUpdates)


### PR DESCRIPTION
When we archive a document history, send all the entries to S3 and record the status and last version in the docHistoryStats collection, instead of keeping the last op in the docHistory collection (since this ultimately leaves an op in docHistory for every project).