### PR TITLE
Pack in place

### DIFF
--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -136,9 +136,7 @@ module.exports = MongoManager =
 		# For finding all updates that go into a diff for a doc
 		db.docHistory.ensureIndex { doc_id: 1, v: 1 }, { background: true }
 		# For finding all updates that affect a project
-		db.docHistory.ensureIndex { project_id: 1, "meta.end_ts": 1 }, { background: true }
-		# For finding all packs that affect a project (use a sparse index so only packs are included)
-		db.docHistory.ensureIndex { project_id: 1, "pack.0.meta.end_ts": 1, "meta.end_ts": 1}, { background: true, sparse: true }
+		db.docHistory.ensureIndex { project_id: 1, "meta.end_ts": 1, "meta.start_ts": -1 }, { background: true }
 		# For finding updates that don't yet have a project_id and need it inserting
 		db.docHistory.ensureIndex { doc_id: 1, project_id: 1 }, { background: true }
 		# For finding project meta-data

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -300,6 +300,7 @@ module.exports = PackManager =
 				top.pack = [ {v: d.v, meta: d.meta,  op: d.op, _id: d._id} ]
 				top.meta = { start_ts: d.meta.start_ts, end_ts: d.meta.end_ts }
 				top.sz = sz
+				top.v_end = d.v
 				delete top.op
 				delete top._id
 				packs.push top

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -269,15 +269,10 @@ module.exports = PackManager =
 
 	MAX_SIZE:  1024*1024 # make these configurable parameters
 	MAX_COUNT: 1024
-	MIN_COUNT: 100
-	KEEP_OPS:  100
 
 	convertDocsToPacks: (docs, callback) ->
 		packs = []
 		top = null
-		# keep the last KEEP_OPS as individual ops
-		docs = docs.slice(0,-PackManager.KEEP_OPS)
-
 		docs.forEach (d,i) ->
 			# skip existing packs
 			if d.pack?
@@ -294,7 +289,7 @@ module.exports = PackManager =
 				top.v_end = d.v
 				top.meta.end_ts = d.meta.end_ts
 				return
-			else if sz < PackManager.MAX_SIZE
+			else
 				# create a new pack
 				top = _.clone(d)
 				top.pack = [ {v: d.v, meta: d.meta,  op: d.op, _id: d._id} ]
@@ -304,13 +299,7 @@ module.exports = PackManager =
 				delete top.op
 				delete top._id
 				packs.push top
-			else
-				# keep the op
-				# util.log "keeping large op unchanged (#{sz} bytes)"
 
-		# only store packs with a sufficient number of ops, discard others
-		packs = packs.filter (packObj) ->
-			packObj.pack.length > PackManager.MIN_COUNT
 		callback(null, packs)
 
 	checkHistory: (docs, callback) ->

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -88,6 +88,10 @@ module.exports = PackManager =
 
 		needMore = false  # keep track of whether we need to load more data
 		updates = [] # used to accumulate the set of results
+
+		# FIXME: packs are big so we should accumulate the results
+		# incrementally instead of using .toArray() to avoid reading all
+		# of the changes into memory
 		cursor.toArray (err, result) ->
 			unpackedSet = PackManager._unpackResults(result)
 			updates = PackManager._filterAndLimit(updates, unpackedSet, filterFn, limit)
@@ -141,6 +145,9 @@ module.exports = PackManager =
 
 		updates = [] # used to accumulate the set of results
 
+		# FIXME: packs are big so we should accumulate the results
+		# incrementally instead of using .toArray() to avoid reading all
+		# of the changes into memory
 		cursor.toArray (err, result) ->
 			if err?
 				return callback err, result

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -409,7 +409,7 @@ module.exports = PackManager =
 					}, {upsert:true}, () ->
 						callback null, null
 
-	DB_WRITE_DELAY: 2000
+	DB_WRITE_DELAY: 100
 
 	savePacks: (packs, callback) ->
 		async.eachSeries packs, PackManager.safeInsert, (err, result) ->

--- a/app/coffee/PackManager.coffee
+++ b/app/coffee/PackManager.coffee
@@ -268,7 +268,7 @@ module.exports = PackManager =
 		return newResults
 
 	MAX_SIZE:  1024*1024 # make these configurable parameters
-	MAX_COUNT: 1024
+	MAX_COUNT: 512
 
 	convertDocsToPacks: (docs, callback) ->
 		packs = []

--- a/test/acceptance/coffee/AppendingUpdatesTests.coffee
+++ b/test/acceptance/coffee/AppendingUpdatesTests.coffee
@@ -37,7 +37,7 @@ describe "Appending doc ops to the history", ->
 					done()
 
 		it "should insert the compressed op into mongo", ->
-			expect(@updates[0].op).to.deep.equal [{
+			expect(@updates[0].pack[0].op).to.deep.equal [{
 				p: 3, i: "foo"
 			}]
 
@@ -99,13 +99,13 @@ describe "Appending doc ops to the history", ->
 						throw error if error?
 						done()
 
-			it "should combine all the updates into one", ->
-				expect(@updates[0].op).to.deep.equal [{
-					p: 3, i: "foobar"
+			it "should combine all the updates into one pack", ->
+				expect(@updates[0].pack[1].op).to.deep.equal [{
+					p: 6, i: "bar"
 				}]
 
 			it "should insert the correct version number into mongo", ->
-				expect(@updates[0].v).to.equal 8
+				expect(@updates[0].v_end).to.equal 8
 
 
 		describe "when the updates are far apart", ->
@@ -129,11 +129,11 @@ describe "Appending doc ops to the history", ->
 						throw error if error?
 						done()
 
-			it "should keep the updates separate", ->
-				expect(@updates[0].op).to.deep.equal [{
+			it "should combine the updates into one pack", ->
+				expect(@updates[0].pack[0].op).to.deep.equal [{
 					p: 3, i: "foo"
 				}]
-				expect(@updates[1].op).to.deep.equal [{
+				expect(@updates[0].pack[1].op).to.deep.equal [{
 					p: 6, i: "bar"
 				}]
 
@@ -160,10 +160,10 @@ describe "Appending doc ops to the history", ->
 					done()
 
 		it "should concat the compressed op into mongo", ->
-			expect(@updates[0].op).to.deep.equal @expectedOp
+			expect(@updates[0].pack.length).to.deep.equal 3  # batch size is 100
 
 		it "should insert the correct version number into mongo", ->
-			expect(@updates[0].v).to.equal 250
+			expect(@updates[0].v_end).to.equal 250
 
 
 	describe "when there are multiple ops in each update", ->
@@ -188,16 +188,16 @@ describe "Appending doc ops to the history", ->
 					done()
 
 		it "should insert the compressed ops into mongo", ->
-			expect(@updates[0].op).to.deep.equal [{
+			expect(@updates[0].pack[0].op).to.deep.equal [{
 				p: 3, i: "foo"
 			}]
-			expect(@updates[1].op).to.deep.equal [{
+			expect(@updates[0].pack[1].op).to.deep.equal [{
 				p: 6, i: "bar"
 			}]
 
 		it "should insert the correct version numbers into mongo", ->
-			expect(@updates[0].v).to.equal 3
-			expect(@updates[1].v).to.equal 4
+			expect(@updates[0].pack[0].v).to.equal 3
+			expect(@updates[0].pack[1].v).to.equal 4
 
 	describe "when there is a no-op update", ->
 		before (done) ->
@@ -221,17 +221,17 @@ describe "Appending doc ops to the history", ->
 					done()
 
 		it "should insert the compressed no-op into mongo", ->
-			expect(@updates[0].op).to.deep.equal []
+			expect(@updates[0].pack[0].op).to.deep.equal []
 
 
 		it "should insert the compressed next update into mongo", ->
-			expect(@updates[1].op).to.deep.equal [{
+			expect(@updates[0].pack[1].op).to.deep.equal [{
 				p: 3, i: "foo"
 			}]
 
 		it "should insert the correct version numbers into mongo", ->
-			expect(@updates[0].v).to.equal 3
-			expect(@updates[1].v).to.equal 4
+			expect(@updates[0].pack[0].v).to.equal 3
+			expect(@updates[0].pack[1].v).to.equal 4
 
 	describe "when the project has versioning enabled", ->
 		before (done) ->

--- a/test/acceptance/coffee/ArchivingUpdatesTests.coffee
+++ b/test/acceptance/coffee/ArchivingUpdatesTests.coffee
@@ -89,9 +89,10 @@ describe "Archiving updates", ->
 				doc.lastVersion.should.equal 20
 				done()
 
-		it "should store twenty doc changes in S3", (done) ->
+		it "should store twenty doc changes in S3 in one pack", (done) ->
 			TrackChangesClient.getS3Doc @project_id, @doc_id, (error, res, doc) =>
-				doc.length.should.equal 20
+				doc.length.should.equal 1
+				doc[0].pack.length.should.equal 20
 				done()
 
 	describe "unarchiving a doc's updates", ->
@@ -103,7 +104,7 @@ describe "Archiving updates", ->
 		it "should restore doc changes", (done) ->
 			db.docHistory.count { doc_id: ObjectId(@doc_id) }, (error, count) ->
 				throw error if error?
-				count.should.equal 20
+				count.should.equal 1
 				done()
 
 		it "should remove doc marked as inS3", (done) ->

--- a/test/acceptance/coffee/FlushingUpdatesTests.coffee
+++ b/test/acceptance/coffee/FlushingUpdatesTests.coffee
@@ -31,7 +31,7 @@ describe "Flushing updates", ->
 
 		it "should flush the op into mongo", (done) ->
 			TrackChangesClient.getCompressedUpdates @doc_id, (error, updates) ->
-				expect(updates[0].op).to.deep.equal [{
+				expect(updates[0].pack[0].op).to.deep.equal [{
 					p: 3, i: "f"
 				}]
 				done()

--- a/test/unit/coffee/PackManager/PackManagerTests.coffee
+++ b/test/unit/coffee/PackManager/PackManagerTests.coffee
@@ -1,0 +1,232 @@
+sinon = require('sinon')
+chai = require('chai')
+should = chai.should()
+expect = chai.expect
+modulePath = "../../../../app/js/PackManager.js"
+SandboxedModule = require('sandboxed-module')
+{ObjectId} = require("mongojs")
+bson = require("bson")
+BSON = new bson.BSONPure()
+
+tk = require "timekeeper"
+
+describe "PackManager", ->
+	beforeEach ->
+		tk.freeze(new Date())
+		@PackManager = SandboxedModule.require modulePath, requires:
+			"./mongojs" : { db: @db = {}, ObjectId: ObjectId, BSON: BSON }
+			"./LockManager" : {}
+			"logger-sharelatex": { log: sinon.stub(), error: sinon.stub() }
+		@callback = sinon.stub()
+		@doc_id = ObjectId().toString()
+		@project_id = ObjectId().toString()
+
+	afterEach ->
+		tk.reset()
+
+	describe "insertCompressedUpdates", ->
+		beforeEach ->
+			@lastUpdate = {
+				_id: "12345"
+				pack: [
+					{ op: "op-1", meta: "meta-1", v: 1},
+					{ op: "op-2", meta: "meta-2", v: 2}
+				]
+				n : 2
+				sz : 100
+			}
+			@newUpdates = [
+				{ op: "op-3", meta: "meta-3", v: 3},
+				{ op: "op-4", meta: "meta-4", v: 4}
+			]
+			@db.docHistory =
+				insert: sinon.stub().callsArg(1)
+				findAndModify: sinon.stub().callsArg(1)
+
+		describe "with no last update", ->
+			beforeEach ->
+				@PackManager.insertUpdatesIntoNewPack = sinon.stub().callsArg(4)
+				@PackManager.insertCompressedUpdates @project_id, @doc_id, null, @newUpdates, true, @callback
+
+			describe "for a small update", ->
+				it "should insert the update into a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates, true).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+			describe "for many small updates", ->
+				beforeEach ->
+					@newUpdates = ({ op: "op-#{i}", meta: "meta-#{i}", v: i} for i in [0..2048])
+					@PackManager.insertCompressedUpdates @project_id, @doc_id, null, @newUpdates, false, @callback
+
+				it "should append the initial updates to the existing pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[0...512], false).should.equal true
+
+				it "should insert the first set remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[512...1024], false).should.equal true
+
+				it "should insert the second set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[1024...1536], false).should.equal true
+
+				it "should insert the third set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[1536...2048], false).should.equal true
+
+				it "should insert the final set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[2048..2048], false).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+
+
+		describe "with an existing pack as the last update", ->
+			beforeEach ->
+				@PackManager.appendUpdatesToExistingPack = sinon.stub().callsArg(5)
+				@PackManager.insertUpdatesIntoNewPack = sinon.stub().callsArg(4)
+				@PackManager.insertCompressedUpdates @project_id, @doc_id, @lastUpdate, @newUpdates, false, @callback
+
+			describe "for a small update", ->
+				it "should append the update to the existing pack", ->
+					@PackManager.appendUpdatesToExistingPack.calledWith(@project_id, @doc_id, @lastUpdate, @newUpdates, false).should.equal true
+				it "should not insert any new packs", ->
+					@PackManager.insertUpdatesIntoNewPack.called.should.equal false
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+			describe "for many small updates", ->
+				beforeEach ->
+					@newUpdates = ({ op: "op-#{i}", meta: "meta-#{i}", v: i} for i in [0..2048])
+					@PackManager.insertCompressedUpdates @project_id, @doc_id, @lastUpdate, @newUpdates, false, @callback
+
+				it "should append the initial updates to the existing pack", ->
+					@PackManager.appendUpdatesToExistingPack.calledWith(@project_id, @doc_id, @lastUpdate, @newUpdates[0...510], false).should.equal true
+
+				it "should insert the first set remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[510...1022], false).should.equal true
+
+				it "should insert the second set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[1022...1534], false).should.equal true
+
+				it "should insert the third set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[1534...2046], false).should.equal true
+
+				it "should insert the final set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[2046..2048], false).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+			describe "for many big updates", ->
+				beforeEach ->
+					longString = ("a" for [0 .. (0.75*@PackManager.MAX_SIZE)]).join("")
+					@newUpdates = ({ op: "op-#{i}-#{longString}", meta: "meta-#{i}", v: i} for i in [0..4])
+					@PackManager.insertCompressedUpdates @project_id, @doc_id, @lastUpdate, @newUpdates, false, @callback
+
+				it "should append the initial updates to the existing pack", ->
+					@PackManager.appendUpdatesToExistingPack.calledWith(@project_id, @doc_id, @lastUpdate, @newUpdates[0..0], false).should.equal true
+
+				it "should insert the first set remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[1..1], false).should.equal true
+
+				it "should insert the second set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[2..2], false).should.equal true
+
+				it "should insert the third set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[3..3], false).should.equal true
+
+				it "should insert the final set of remaining updates as a new pack", ->
+					@PackManager.insertUpdatesIntoNewPack.calledWith(@project_id, @doc_id, @newUpdates[4..4], false).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+		describe "flushCompressedUpdates", ->
+			describe "when there is no previous update",  ->
+				beforeEach ->
+					@PackManager.flushCompressedUpdates @project_id, @doc_id, null, @newUpdates, true, @callback
+
+				describe "for a small update  that will expire", ->
+					it "should insert the update into mongo", ->
+						@db.docHistory.insert.calledWithMatch({
+							pack: @newUpdates,
+							project_id: ObjectId(@project_id),
+							doc_id: ObjectId(@doc_id)
+							n: @newUpdates.length
+							v: @newUpdates[0].v
+							v_end: @newUpdates[@newUpdates.length-1].v
+						}).should.equal true
+
+					it "should set an expiry time in the future", ->
+						@db.docHistory.insert.calledWithMatch({
+							expiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000)
+						}).should.equal true
+
+					it "should call the callback", ->
+						@callback.called.should.equal true
+
+		describe "when there is a recent previous update in mongo", ->
+			beforeEach ->
+				@lastUpdate = {
+					_id: "12345"
+					pack: [
+						{ op: "op-1", meta: "meta-1", v: 1},
+						{ op: "op-2", meta: "meta-2", v: 2}
+					]
+					n : 2
+					sz : 100
+					expiresAt: new Date(Date.now())
+				}
+
+				@PackManager.flushCompressedUpdates @project_id, @doc_id, @lastUpdate, @newUpdates, true, @callback
+
+			describe "for a small update that will expire", ->
+				it "should append the update in mongo", ->
+					@db.docHistory.findAndModify.calledWithMatch({
+						query: {_id: @lastUpdate._id}
+						update: { $push: {"pack" : {$each: @newUpdates}}, $set: {v_end: @newUpdates[@newUpdates.length-1].v}}
+					}).should.equal true
+
+				it "should set an expiry time in the future", ->
+					@db.docHistory.findAndModify.calledWithMatch({
+						update: {$set: {expiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000)}}
+					}).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true
+
+
+		describe "when there is an old previous update in mongo", ->
+			beforeEach ->
+				@lastUpdate = {
+					_id: "12345"
+					pack: [
+						{ op: "op-1", meta: "meta-1", v: 1},
+						{ op: "op-2", meta: "meta-2", v: 2}
+					]
+					n : 2
+					sz : 100
+					meta: {start_ts: Date.now() - 30 * 24 * 3600 * 1000}
+					expiresAt: new Date(Date.now() - 30 * 24 * 3600 * 1000)
+				}
+
+				@PackManager.flushCompressedUpdates @project_id, @doc_id, @lastUpdate, @newUpdates, true, @callback
+
+			describe "for a small update that will expire", ->
+				it "should insert the update into mongo", ->
+					@db.docHistory.insert.calledWithMatch({
+						pack: @newUpdates,
+						project_id: ObjectId(@project_id),
+						doc_id: ObjectId(@doc_id)
+						n: @newUpdates.length
+						v: @newUpdates[0].v
+						v_end: @newUpdates[@newUpdates.length-1].v
+					}).should.equal true
+
+				it "should set an expiry time in the future", ->
+					@db.docHistory.insert.calledWithMatch({
+						expiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000)
+					}).should.equal true
+
+				it "should call the callback", ->
+					@callback.called.should.equal true

--- a/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
+++ b/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
@@ -67,6 +67,7 @@ describe "UpdatesManager", ->
 				@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, @lastCompressedUpdate, @lastCompressedUpdate.v)
 				@MongoManager.modifyCompressedUpdate = sinon.stub().callsArg(2)
 				@MongoManager.insertCompressedUpdates = sinon.stub().callsArg(4)
+				@PackManager.insertCompressedUpdates = sinon.stub().callsArg(5)
 				@UpdateCompressor.compressRawUpdates = sinon.stub().returns(@compressedUpdates)
 
 			describe "when the raw ops start where the existing history ends", ->
@@ -109,7 +110,7 @@ describe "UpdatesManager", ->
 						.calledWith(@doc_id)
 						.should.equal true
 
-				it "should defer the compression of raw ops to PackManager", ->
+				it "should defer the compression of raw ops until they are written in a new pack", ->
 					@UpdateCompressor.compressRawUpdates
 						.should.not.be.called
 

--- a/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
+++ b/test/unit/coffee/UpdatesManager/UpdatesManagerTests.coffee
@@ -10,6 +10,7 @@ describe "UpdatesManager", ->
 		@UpdatesManager = SandboxedModule.require modulePath, requires:
 			"./UpdateCompressor": @UpdateCompressor = {}
 			"./MongoManager" : @MongoManager = {}
+			"./PackManager" : @PackManager = {}
 			"./RedisManager" : @RedisManager = {}
 			"./LockManager"  : @LockManager = {}
 			"./WebApiManager": @WebApiManager = {}
@@ -41,8 +42,7 @@ describe "UpdatesManager", ->
 				@compressedUpdates = [ { v: 13, op: "compressed-op-12" } ]
 
 				@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, null)
-				@MongoManager.modifyCompressedUpdate = sinon.stub().callsArg(2)
-				@MongoManager.insertCompressedUpdates = sinon.stub().callsArg(4)
+				@PackManager.insertCompressedUpdates = sinon.stub().callsArg(5)
 				@UpdateCompressor.compressRawUpdates = sinon.stub().returns(@compressedUpdates)
 				@UpdatesManager.compressAndSaveRawUpdates @project_id, @doc_id, @rawUpdates, @temporary, @callback
 
@@ -51,15 +51,11 @@ describe "UpdatesManager", ->
 					.calledWith(@doc_id)
 					.should.equal true
 			
-			it "should compress the raw ops", ->
-				@UpdateCompressor.compressRawUpdates
-					.calledWith(null, @rawUpdates)
-					.should.equal true
-			
 			it "should save the compressed ops", ->
-				@MongoManager.insertCompressedUpdates
-					.calledWith(@project_id, @doc_id, @compressedUpdates, @temporary)
+				@PackManager.insertCompressedUpdates
+					.calledWith(@project_id, @doc_id, null, @compressedUpdates, @temporary)
 					.should.equal true
+
 
 			it "should call the callback", ->
 				@callback.called.should.equal true
@@ -136,8 +132,7 @@ describe "UpdatesManager", ->
 				@compressedUpdates = [ { v: 13, op: "compressed-op-12" } ]
 
 				@MongoManager.peekLastCompressedUpdate = sinon.stub().callsArgWith(1, null, null, @lastVersion)
-				@MongoManager.modifyCompressedUpdate = sinon.stub().callsArg(2)
-				@MongoManager.insertCompressedUpdates = sinon.stub().callsArg(4)
+				@PackManager.insertCompressedUpdates = sinon.stub().callsArg(5)
 				@UpdateCompressor.compressRawUpdates = sinon.stub().returns(@compressedUpdates)
 
 			describe "when the raw ops start where the existing history ends", ->
@@ -156,8 +151,8 @@ describe "UpdatesManager", ->
 						.should.equal true
 				
 				it "should save the compressed ops", ->
-					@MongoManager.insertCompressedUpdates
-						.calledWith(@project_id, @doc_id, @compressedUpdates, @temporary)
+					@PackManager.insertCompressedUpdates
+						.calledWith(@project_id, @doc_id, null, @compressedUpdates, @temporary)
 						.should.equal true
 
 				it "should call the callback", ->


### PR DESCRIPTION
Write all new docHistory ops into packs, to avoid filling mongo index with a lot of small objects.