### PR TITLE
update timeouts to allow for 5 second retry delay

### DIFF
--- a/app/coffee/HealthChecker.coffee
+++ b/app/coffee/HealthChecker.coffee
@@ -22,7 +22,7 @@ module.exports =
 					else
 						cb()
 			(cb)->
-				request.post {url:"#{url}/flush", timeout:3000}, (err, res, body) ->
+				request.post {url:"#{url}/flush", timeout:10000}, (err, res, body) ->
 					if err?
 						logger.err err:err, project_id:project_id, "error flushing for health check"
 						cb(err)
@@ -31,7 +31,7 @@ module.exports =
 					else
 						cb()
 			(cb)->
-				request.get {url:"#{url}/updates", timeout:3000}, (err, res, body)->
+				request.get {url:"#{url}/updates", timeout:10000}, (err, res, body)->
 					if err?
 						logger.err err:err, project_id:project_id, "error getting updates for health check"
 						cb(err)

--- a/app/coffee/WebApiManager.coffee
+++ b/app/coffee/WebApiManager.coffee
@@ -3,7 +3,7 @@ logger = require "logger-sharelatex"
 Settings = require "settings-sharelatex"
 
 # Don't let HTTP calls hang for a long time
-MAX_HTTP_REQUEST_LENGTH = 30000 # 30 seconds
+MAX_HTTP_REQUEST_LENGTH = 15000 # 15 seconds
 
 # DEPRECATED! This method of getting user details via track-changes is deprecated
 # in the way we lay out our services.


### PR DESCRIPTION
now using requestretry module, which has a five second delay between retries. Need to increase the timeout on the health checks to allow for this, as the timeout is currently shorter than the retry delay.