### PR TITLE
fix shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,150 +2,41 @@
   "name": "history-sharelatex",
   "version": "0.1.4",
   "dependencies": {
-    "JSONStream": {
-      "version": "1.3.1",
-      "from": "JSONStream@1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "dependencies": {
-        "jsonparse": {
-          "version": "1.3.0",
-          "from": "jsonparse@1.3.0",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz"
-        },
-        "through": {
-          "version": "2.3.8",
-          "from": "through@2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-        }
-      }
-    },
     "async": {
       "version": "0.2.10",
-      "from": "async@0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-    },
-    "aws-sdk": {
-      "version": "2.37.0",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.37.0.tgz",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.37.0.tgz",
-      "dependencies": {
-        "buffer": {
-          "version": "4.9.1",
-          "from": "buffer@4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "dependencies": {
-            "base64-js": {
-              "version": "1.2.0",
-              "from": "base64-js@1.2.0",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
-            },
-            "ieee754": {
-              "version": "1.1.8",
-              "from": "ieee754@1.1.8",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
-        },
-        "crypto-browserify": {
-          "version": "1.0.9",
-          "from": "crypto-browserify@1.0.9",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
-        },
-        "jmespath": {
-          "version": "0.15.0",
-          "from": "jmespath@0.15.0",
-          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "from": "querystring@0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-        },
-        "sax": {
-          "version": "1.1.5",
-          "from": "sax@1.1.5",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
-        },
-        "url": {
-          "version": "0.10.3",
-          "from": "url@0.10.3",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "from": "punycode@1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.0.0",
-          "from": "uuid@3.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
-        },
-        "xml2js": {
-          "version": "0.4.15",
-          "from": "xml2js@0.4.15",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
-        },
-        "xmlbuilder": {
-          "version": "2.6.2",
-          "from": "xmlbuilder@2.6.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0",
-              "from": "lodash@3.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-            }
-          }
-        }
-      }
+      "from": "async@~0.2.10"
     },
     "bson": {
       "version": "0.4.23",
-      "from": "bson@0.4.23",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+      "from": "bson@^0.4.20"
     },
     "byline": {
       "version": "4.2.2",
-      "from": "byline@4.2.2",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.2.tgz"
+      "from": "byline@^4.2.1"
     },
     "cli": {
       "version": "0.6.6",
-      "from": "cli@0.6.6",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+      "from": "cli@^0.6.6",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@~ 3.2.1",
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "from": "inherits@~2.0.1"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@0.3",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@2.7.3",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@1.0.1",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "from": "sigmund@~1.0.0"
                 }
               }
             }
@@ -153,221 +44,291 @@
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+          "from": "exit@0.1.2"
         }
       }
     },
     "express": {
       "version": "3.3.5",
-      "from": "https://registry.npmjs.org/express/-/express-3.3.5.tgz",
+      "from": "express@3.3.5",
       "resolved": "https://registry.npmjs.org/express/-/express-3.3.5.tgz",
       "dependencies": {
         "connect": {
           "version": "2.8.5",
           "from": "connect@2.8.5",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.8.5.tgz",
           "dependencies": {
             "qs": {
               "version": "0.6.5",
-              "from": "qs@0.6.5",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
+              "from": "qs@0.6.5"
             },
             "formidable": {
               "version": "1.0.14",
-              "from": "formidable@1.0.14",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+              "from": "formidable@1.0.14"
             },
             "bytes": {
               "version": "0.2.0",
-              "from": "bytes@0.2.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
+              "from": "bytes@0.2.0"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1",
-              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+              "from": "pause@0.0.1"
             },
             "uid2": {
               "version": "0.0.2",
-              "from": "uid2@0.0.2",
-              "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz"
+              "from": "uid2@0.0.2"
             }
           }
         },
         "commander": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
+          "from": "commander@1.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
           "dependencies": {
             "keypress": {
               "version": "0.1.0",
-              "from": "keypress@0.1.0",
-              "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+              "from": "keypress@0.1.x"
             }
           }
         },
         "range-parser": {
           "version": "0.0.4",
-          "from": "range-parser@0.0.4",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+          "from": "range-parser@0.0.4"
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "from": "mkdirp@0.3.x"
         },
         "cookie": {
           "version": "0.1.0",
-          "from": "cookie@0.1.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+          "from": "cookie@0.1.0"
         },
         "buffer-crc32": {
           "version": "0.2.1",
-          "from": "buffer-crc32@0.2.1",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+          "from": "buffer-crc32@0.2.1"
         },
         "fresh": {
           "version": "0.2.0",
-          "from": "fresh@0.2.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
+          "from": "fresh@0.2.0"
         },
         "methods": {
           "version": "0.0.1",
-          "from": "methods@0.0.1",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+          "from": "methods@0.0.1"
         },
         "send": {
           "version": "0.1.4",
           "from": "send@0.1.4",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
           "dependencies": {
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "from": "mime@~1.2.9"
             }
           }
         },
         "cookie-signature": {
           "version": "1.0.1",
-          "from": "cookie-signature@1.0.1",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+          "from": "cookie-signature@1.0.1"
         },
         "debug": {
           "version": "2.6.3",
-          "from": "debug@2.6.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+          "from": "debug@*",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
-              "from": "ms@0.7.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+              "from": "ms@0.7.2"
             }
           }
         }
       }
     },
-    "heap": {
-      "version": "0.2.6",
-      "from": "heap@0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz"
-    },
     "line-reader": {
       "version": "0.2.4",
-      "from": "line-reader@0.2.4",
-      "resolved": "https://registry.npmjs.org/line-reader/-/line-reader-0.2.4.tgz"
+      "from": "line-reader@^0.2.4"
+    },
+    "mongojs": {
+      "version": "1.4.1",
+      "from": "mongojs@^1.4.1",
+      "dependencies": {
+        "each-series": {
+          "version": "1.0.0",
+          "from": "each-series@^1.0.0"
+        },
+        "mongodb-core": {
+          "version": "1.3.22-alpha4",
+          "from": "mongodb-core@^1.2.8",
+          "dependencies": {
+            "require_optional": {
+              "version": "1.0.0",
+              "from": "require_optional@~1.0.0",
+              "dependencies": {
+                "semver": {
+                  "version": "5.3.0",
+                  "from": "semver@^5.1.0"
+                },
+                "resolve-from": {
+                  "version": "2.0.0",
+                  "from": "resolve-from@^2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "from": "once@^1.3.2",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "from": "wrappy@1"
+            }
+          }
+        },
+        "parse-mongo-url": {
+          "version": "1.1.1",
+          "from": "parse-mongo-url@^1.1.0"
+        },
+        "pump": {
+          "version": "1.0.2",
+          "from": "pump@^1.0.0",
+          "dependencies": {
+            "end-of-stream": {
+              "version": "1.4.0",
+              "from": "end-of-stream@^1.1.0"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.6",
+          "from": "readable-stream@^2.0.2",
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "buffer-shims@^1.0.0"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@~1.0.0"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@~1.0.0"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@~2.0.1"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@~1.0.6"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@~0.10.x"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@~1.0.1"
+            }
+          }
+        },
+        "thunky": {
+          "version": "0.1.0",
+          "from": "thunky@^0.1.0"
+        },
+        "to-mongodb-core": {
+          "version": "2.0.0",
+          "from": "to-mongodb-core@^2.0.0"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@^4.0.0"
+        }
+      }
+    },
+    "settings-sharelatex": {
+      "version": "1.0.0",
+      "from": "settings-sharelatex@git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+      "resolved": "git+https://github.com/sharelatex/settings-sharelatex.git#cbc5e41c1dbe6789721a14b3fdae05bf22546559",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.0",
+          "from": "coffee-script@1.6.0"
+        }
+      }
     },
     "logger-sharelatex": {
       "version": "1.5.6",
-      "from": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.5.6",
+      "from": "logger-sharelatex@git+https://github.com/sharelatex/logger-sharelatex.git#v1.5.6",
       "resolved": "git+https://github.com/sharelatex/logger-sharelatex.git#b2956ec56b582b9f4fc8fdda8dc00c06e77c5537",
       "dependencies": {
         "bunyan": {
           "version": "1.5.1",
           "from": "bunyan@1.5.1",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.5.1.tgz",
           "dependencies": {
             "dtrace-provider": {
               "version": "0.6.0",
-              "from": "dtrace-provider@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+              "from": "dtrace-provider@~0.6",
               "dependencies": {
                 "nan": {
-                  "version": "2.6.2",
-                  "from": "nan@>=2.0.8 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+                  "version": "2.5.1",
+                  "from": "nan@^2.0.8"
                 }
               }
             },
             "mv": {
               "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "from": "mv@~2",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@~0.5.1",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "from": "minimist@0.0.8"
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                  "from": "ncp@~2.0.0"
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "from": "rimraf@~2.4.0",
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                      "from": "glob@^6.0.1",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "from": "inflight@^1.0.4",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                          "from": "inherits@2"
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "from": "minimatch@2 || 3",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.7",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                              "version": "1.1.6",
+                              "from": "brace-expansion@^1.0.0",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                  "from": "balanced-match@^0.4.1"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "from": "concat-map@0.0.1"
                                 }
                               }
                             }
@@ -375,20 +336,17 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "from": "once@^1.3.0",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                          "from": "path-is-absolute@^1.0.0"
                         }
                       }
                     }
@@ -398,8 +356,7 @@
             },
             "safe-json-stringify": {
               "version": "1.0.4",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
+              "from": "safe-json-stringify@~1"
             }
           }
         },
@@ -410,181 +367,149 @@
         },
         "grunt-contrib-clean": {
           "version": "0.6.0",
-          "from": "grunt-contrib-clean@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+          "from": "grunt-contrib-clean@^0.6.0",
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.1 <2.3.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+              "from": "rimraf@~2.2.1"
             }
           }
         },
         "grunt-contrib-coffee": {
           "version": "0.11.1",
-          "from": "grunt-contrib-coffee@0.11.1",
-          "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+          "from": "grunt-contrib-coffee@^0.11.0",
           "dependencies": {
             "coffee-script": {
               "version": "1.7.1",
-              "from": "coffee-script@>=1.7.0 <1.8.0",
-              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+              "from": "coffee-script@~1.7.0",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "from": "mkdirp@~0.3.5"
                 }
               }
             },
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@~0.5.0",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                  "from": "ansi-styles@^1.1.0"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "from": "escape-string-regexp@^1.0.0"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@^0.1.0",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "from": "ansi-regex@^0.2.1"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@^0.3.0",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "from": "ansi-regex@^0.2.1"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                  "from": "supports-color@^0.2.0"
                 }
               }
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+              "from": "lodash@~2.4.1"
             }
           }
         },
         "grunt-execute": {
           "version": "0.2.2",
-          "from": "grunt-execute@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/grunt-execute/-/grunt-execute-0.2.2.tgz"
+          "from": "grunt-execute@^0.2.2"
         },
         "grunt-mocha-test": {
           "version": "0.11.0",
-          "from": "grunt-mocha-test@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.11.0.tgz",
+          "from": "grunt-mocha-test@^0.11.0",
           "dependencies": {
             "mocha": {
               "version": "1.20.1",
-              "from": "mocha@>=1.20.0 <1.21.0",
-              "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.1.tgz",
+              "from": "mocha@~1.20.0",
               "dependencies": {
                 "commander": {
                   "version": "2.0.0",
-                  "from": "commander@2.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+                  "from": "commander@2.0.0"
                 },
                 "growl": {
                   "version": "1.7.0",
-                  "from": "growl@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+                  "from": "growl@1.7.x"
                 },
                 "jade": {
                   "version": "0.26.3",
                   "from": "jade@0.26.3",
-                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                      "from": "commander@0.6.1"
                     },
                     "mkdirp": {
                       "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                      "from": "mkdirp@0.3.0"
                     }
                   }
                 },
                 "diff": {
                   "version": "1.0.7",
-                  "from": "diff@1.0.7",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+                  "from": "diff@1.0.7"
                 },
                 "debug": {
-                  "version": "2.6.4",
+                  "version": "2.6.3",
                   "from": "debug@*",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.3",
-                      "from": "ms@0.7.3",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.5",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "from": "mkdirp@0.3.5"
                 },
                 "glob": {
                   "version": "3.2.3",
                   "from": "glob@3.2.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@~0.2.11",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.3",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                          "from": "lru-cache@2"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                          "from": "sigmund@~1.0.0"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                      "from": "graceful-fs@~2.0.0"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "from": "inherits@2"
                     }
                   }
                 }
@@ -592,87 +517,71 @@
             },
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+              "from": "hooker@~0.2.3"
             },
             "fs-extra": {
               "version": "0.9.1",
-              "from": "fs-extra@>=0.9.1 <0.10.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
+              "from": "fs-extra@~0.9.1",
               "dependencies": {
                 "ncp": {
                   "version": "0.5.1",
-                  "from": "ncp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+                  "from": "ncp@^0.5.1"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@^0.5.0",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "from": "minimist@0.0.8"
                     }
                   }
                 },
                 "jsonfile": {
                   "version": "1.1.1",
-                  "from": "jsonfile@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz"
+                  "from": "jsonfile@~1.1.0"
                 },
                 "rimraf": {
                   "version": "2.6.1",
-                  "from": "rimraf@>=2.2.8 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                  "from": "rimraf@^2.2.8",
                   "dependencies": {
                     "glob": {
                       "version": "7.1.1",
-                      "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                      "from": "glob@^7.0.5",
                       "dependencies": {
                         "fs.realpath": {
                           "version": "1.0.0",
-                          "from": "fs.realpath@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                          "from": "fs.realpath@^1.0.0"
                         },
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "from": "inflight@^1.0.4",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                          "from": "inherits@2"
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "from": "minimatch@^3.0.2",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.7",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                              "version": "1.1.6",
+                              "from": "brace-expansion@^1.0.0",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                  "from": "balanced-match@^0.4.1"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "from": "concat-map@0.0.1"
                                 }
                               }
                             }
@@ -680,20 +589,17 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "from": "once@^1.3.0",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                          "from": "path-is-absolute@^1.0.0"
                         }
                       }
                     }
@@ -704,234 +610,439 @@
           }
         },
         "raven": {
-          "version": "1.2.1",
-          "from": "raven@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
+          "version": "1.2.0",
+          "from": "raven@^1.1.3",
           "dependencies": {
             "cookie": {
               "version": "0.3.1",
-              "from": "cookie@0.3.1",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+              "from": "cookie@0.3.1"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "from": "json-stringify-safe@5.0.1"
             },
             "lsmod": {
               "version": "1.0.0",
-              "from": "lsmod@1.0.0",
-              "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz"
+              "from": "lsmod@1.0.0"
             },
             "uuid": {
               "version": "3.0.0",
-              "from": "uuid@3.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
+              "from": "uuid@3.0.0"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@0.0.9",
-              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+              "from": "stack-trace@0.0.9"
             }
           }
         },
         "timekeeper": {
           "version": "1.0.0",
-          "from": "timekeeper@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-1.0.0.tgz"
+          "from": "timekeeper@^1.0.0"
         }
       }
     },
     "metrics-sharelatex": {
       "version": "1.7.1",
-      "from": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
+      "from": "metrics-sharelatex@git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
       "resolved": "git+https://github.com/sharelatex/metrics-sharelatex.git#166961924c599b1f9468f2e17846fa2a9d12372d",
       "dependencies": {
         "lynx": {
           "version": "0.1.1",
-          "from": "lynx@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/lynx/-/lynx-0.1.1.tgz",
+          "from": "lynx@~0.1.1",
           "dependencies": {
             "mersenne": {
               "version": "0.0.3",
-              "from": "mersenne@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.3.tgz"
+              "from": "mersenne@~0.0.3"
             },
             "statsd-parser": {
               "version": "0.0.4",
-              "from": "statsd-parser@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/statsd-parser/-/statsd-parser-0.0.4.tgz"
+              "from": "statsd-parser@~0.0.4"
             }
           }
         },
         "coffee-script": {
           "version": "1.6.0",
-          "from": "coffee-script@1.6.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz"
+          "from": "coffee-script@1.6.0"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+          "from": "underscore@~1.6.0"
         }
       }
     },
-    "mongo-uri": {
-      "version": "0.1.2",
-      "from": "mongo-uri@0.1.2",
-      "resolved": "https://registry.npmjs.org/mongo-uri/-/mongo-uri-0.1.2.tgz"
-    },
-    "mongojs": {
-      "version": "1.4.1",
-      "from": "mongojs@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-1.4.1.tgz",
+    "request": {
+      "version": "2.33.0",
+      "from": "request@~2.33.0",
       "dependencies": {
-        "each-series": {
-          "version": "1.0.0",
-          "from": "each-series@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz"
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@~0.6.0"
         },
-        "mongodb-core": {
-          "version": "1.3.21",
-          "from": "mongodb-core@>=1.2.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.21.tgz",
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@~5.0.0"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@~0.5.0"
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "from": "node-uuid@~1.4.0"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@~1.2.9"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=0.12.0",
           "dependencies": {
-            "require_optional": {
-              "version": "1.0.0",
-              "from": "require_optional@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@^1.4.1"
+            }
+          }
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@~0.1.0",
+          "dependencies": {
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@~0.0.4",
               "dependencies": {
-                "semver": {
-                  "version": "5.3.0",
-                  "from": "semver@>=5.1.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                },
-                "resolve-from": {
-                  "version": "2.0.0",
-                  "from": "resolve-from@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5"
                 }
               }
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@~0.9.0"
             }
           }
         },
-        "once": {
-          "version": "1.4.0",
-          "from": "once@>=1.3.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "tunnel-agent": {
+          "version": "0.3.0",
+          "from": "tunnel-agent@~0.3.0"
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "http-signature@~0.10.0",
           "dependencies": {
-            "wrappy": {
-              "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "assert-plus@^0.1.5"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11"
+            },
+            "ctype": {
+              "version": "0.5.3",
+              "from": "ctype@0.5.3"
             }
           }
         },
-        "parse-mongo-url": {
-          "version": "1.1.1",
-          "from": "parse-mongo-url@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz"
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@~0.3.0"
         },
-        "pump": {
-          "version": "1.0.2",
-          "from": "pump@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+        "hawk": {
+          "version": "1.0.0",
+          "from": "hawk@~1.0.0",
           "dependencies": {
-            "end-of-stream": {
-              "version": "1.4.0",
-              "from": "end-of-stream@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@0.9.x"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@0.4.x"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@0.2.x"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@0.2.x"
             }
           }
         },
-        "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "dependencies": {
-            "buffer-shims": {
-              "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-            },
-            "string_decoder": {
-              "version": "1.0.0",
-              "from": "string_decoder@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-          }
-        },
-        "thunky": {
-          "version": "0.1.0",
-          "from": "thunky@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
-        },
-        "to-mongodb-core": {
-          "version": "2.0.0",
-          "from": "to-mongodb-core@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-mongodb-core/-/to-mongodb-core-2.0.0.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@~0.5.0"
         }
       }
     },
-    "redis": {
-      "version": "0.10.3",
-      "from": "redis@0.10.3",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-0.10.3.tgz"
+    "requestretry": {
+      "version": "1.12.0",
+      "from": "requestretry@^1.12.0",
+      "dependencies": {
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@^3.0.0"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@^4.15.0"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@^2.74.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@~0.6.0"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "aws4@^1.2.1"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "caseless@~0.12.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@~1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@~1.0.0"
+                }
+              }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@~0.6.1"
+            },
+            "form-data": {
+              "version": "2.1.2",
+              "from": "form-data@~2.1.1",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@^0.4.0"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "har-validator@~4.2.1",
+              "dependencies": {
+                "ajv": {
+                  "version": "4.11.5",
+                  "from": "ajv@^4.9.1",
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@^4.6.0"
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "from": "json-stable-stringify@^1.0.1",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@~0.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@^1.0.5"
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@~3.1.3",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@2.x.x"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@2.x.x"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@2.x.x"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.x.x"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@~1.1.0",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@^0.2.0"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "jsprim@^1.2.2",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.11.0",
+                  "from": "sshpk@^1.7.0",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@~0.2.3"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@^1.0.0"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@^1.12.0"
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "getpass@^0.1.1"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "jsbn@~0.1.0"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@~0.14.0"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@^1.0.0"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@~0.1.1"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@^1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@~1.0.0"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@~0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@~5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "from": "mime-types@~2.1.7",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.27.0",
+                  "from": "mime-db@~1.27.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@~0.8.1"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@^0.2.0"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@~6.4.0"
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "from": "safe-buffer@^5.0.1"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@~0.0.4"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "from": "tough-cookie@~2.3.0",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@^1.4.1"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "tunnel-agent@^0.6.0"
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "from": "uuid@^3.0.0"
+            }
+          }
+        },
+        "when": {
+          "version": "3.7.8",
+          "from": "when@^3.7.7"
+        }
+      }
     },
     "redis-sharelatex": {
-      "version": "1.0.0",
-      "from": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.0",
-      "resolved": "git+https://github.com/sharelatex/redis-sharelatex.git#f6bc41c578d0830827127d89e2bcd53587f02fa8",
+      "version": "0.0.9",
+      "from": "redis-sharelatex@~0.0.9",
       "dependencies": {
         "chai": {
           "version": "1.9.1",
           "from": "chai@1.9.1",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.1.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "assertion-error@1.0.0",
-              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
+              "from": "assertion-error@1.0.0"
             },
             "deep-eql": {
               "version": "0.1.3",
               "from": "deep-eql@0.1.3",
-              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
-                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                  "from": "type-detect@0.1.1"
                 }
               }
             }
@@ -940,180 +1051,148 @@
         "coffee-script": {
           "version": "1.8.0",
           "from": "coffee-script@1.8.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "from": "mkdirp@~0.3.5"
             }
           }
         },
         "grunt-contrib-coffee": {
           "version": "0.11.1",
-          "from": "grunt-contrib-coffee@0.11.1",
-          "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
+          "from": "grunt-contrib-coffee@^0.11.0",
           "dependencies": {
             "coffee-script": {
               "version": "1.7.1",
-              "from": "coffee-script@>=1.7.0 <1.8.0",
-              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+              "from": "coffee-script@~1.7.0",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "from": "mkdirp@~0.3.5"
                 }
               }
             },
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@~0.5.0",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                  "from": "ansi-styles@^1.1.0"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "from": "escape-string-regexp@^1.0.0"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@^0.1.0",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "from": "ansi-regex@^0.2.0"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@^0.3.0",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "from": "ansi-regex@^0.2.0"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                  "from": "supports-color@^0.2.0"
                 }
               }
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+              "from": "lodash@~2.4.1"
             }
           }
         },
         "grunt-mocha-test": {
           "version": "0.12.0",
           "from": "grunt-mocha-test@0.12.0",
-          "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.0.tgz",
           "dependencies": {
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+              "from": "hooker@~0.2.3"
             },
             "fs-extra": {
               "version": "0.11.1",
-              "from": "fs-extra@>=0.11.1 <0.12.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
+              "from": "fs-extra@~0.11.1",
               "dependencies": {
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "ncp@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
+                  "from": "ncp@^0.6.0"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@^0.5.0",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "from": "minimist@0.0.8"
                     }
                   }
                 },
                 "jsonfile": {
                   "version": "2.4.0",
-                  "from": "jsonfile@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                  "from": "jsonfile@^2.0.0",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "from": "graceful-fs@>=4.1.6 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                      "from": "graceful-fs@^4.1.6"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.6.1",
-                  "from": "rimraf@>=2.2.8 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                  "from": "rimraf@^2.2.8",
                   "dependencies": {
                     "glob": {
                       "version": "7.1.1",
-                      "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                      "from": "glob@^7.0.5",
                       "dependencies": {
                         "fs.realpath": {
                           "version": "1.0.0",
-                          "from": "fs.realpath@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                          "from": "fs.realpath@^1.0.0"
                         },
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "from": "inflight@^1.0.4",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                          "from": "inherits@2"
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "from": "minimatch@2 || 3",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.7",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                              "version": "1.1.6",
+                              "from": "brace-expansion@^1.0.0",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                  "from": "balanced-match@^0.4.1"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "from": "concat-map@0.0.1"
                                 }
                               }
                             }
@@ -1121,20 +1200,17 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "from": "once@^1.3.0",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "from": "wrappy@1"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                          "from": "path-is-absolute@^1.0.0"
                         }
                       }
                     }
@@ -1144,145 +1220,75 @@
             }
           }
         },
-        "ioredis": {
-          "version": "2.5.0",
-          "from": "ioredis@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
-          "dependencies": {
-            "bluebird": {
-              "version": "3.5.0",
-              "from": "bluebird@>=3.3.4 <4.0.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
-            },
-            "cluster-key-slot": {
-              "version": "1.0.8",
-              "from": "cluster-key-slot@>=1.0.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz"
-            },
-            "debug": {
-              "version": "2.6.4",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.3",
-                  "from": "ms@0.7.3",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
-                }
-              }
-            },
-            "double-ended-queue": {
-              "version": "2.1.0-0",
-              "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
-            },
-            "flexbuffer": {
-              "version": "0.0.6",
-              "from": "flexbuffer@0.0.6",
-              "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz"
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "from": "lodash@>=4.8.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-            },
-            "redis-commands": {
-              "version": "1.3.1",
-              "from": "redis-commands@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
-            },
-            "redis-parser": {
-              "version": "1.3.0",
-              "from": "redis-parser@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz"
-            }
-          }
-        },
         "mocha": {
           "version": "1.21.4",
           "from": "mocha@1.21.4",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.4.tgz",
           "dependencies": {
             "commander": {
               "version": "2.0.0",
-              "from": "commander@2.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+              "from": "commander@2.0.0"
             },
             "growl": {
               "version": "1.8.1",
-              "from": "growl@>=1.8.0 <1.9.0",
-              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+              "from": "growl@1.8.x"
             },
             "jade": {
               "version": "0.26.3",
               "from": "jade@0.26.3",
-              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "commander@0.6.1",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                  "from": "commander@0.6.1"
                 },
                 "mkdirp": {
                   "version": "0.3.0",
-                  "from": "mkdirp@0.3.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                  "from": "mkdirp@0.3.0"
                 }
               }
             },
             "diff": {
               "version": "1.0.7",
-              "from": "diff@1.0.7",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+              "from": "diff@1.0.7"
             },
             "debug": {
-              "version": "2.6.4",
+              "version": "2.6.3",
               "from": "debug@*",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.3",
-                  "from": "ms@0.7.3",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+                  "version": "0.7.2",
+                  "from": "ms@0.7.2"
                 }
               }
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@0.3.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "from": "mkdirp@0.3.5"
             },
             "glob": {
               "version": "3.2.3",
               "from": "glob@3.2.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@~0.2.11",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "from": "sigmund@~1.0.0"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                  "from": "graceful-fs@~2.0.0"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "from": "inherits@2"
                 }
               }
             }
@@ -1290,69 +1296,57 @@
         },
         "redis": {
           "version": "0.12.1",
-          "from": "redis@0.12.1",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
+          "from": "redis@0.12.1"
         },
         "redis-sentinel": {
           "version": "0.1.1",
           "from": "redis-sentinel@0.1.1",
-          "resolved": "https://registry.npmjs.org/redis-sentinel/-/redis-sentinel-0.1.1.tgz",
           "dependencies": {
             "redis": {
               "version": "0.11.0",
-              "from": "redis@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.11.0.tgz"
+              "from": "redis@0.11.x"
             },
             "q": {
               "version": "0.9.2",
-              "from": "q@0.9.2",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.2.tgz"
+              "from": "q@0.9.2"
             }
           }
         },
         "sandboxed-module": {
           "version": "1.0.1",
           "from": "sandboxed-module@1.0.1",
-          "resolved": "https://registry.npmjs.org/sandboxed-module/-/sandboxed-module-1.0.1.tgz",
           "dependencies": {
             "require-like": {
               "version": "0.1.2",
-              "from": "require-like@0.1.2",
-              "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz"
+              "from": "require-like@0.1.2"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@0.0.9",
-              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+              "from": "stack-trace@0.0.9"
             }
           }
         },
         "sinon": {
           "version": "1.10.3",
           "from": "sinon@1.10.3",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
           "dependencies": {
             "formatio": {
               "version": "1.0.2",
-              "from": "formatio@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
+              "from": "formatio@~1.0",
               "dependencies": {
                 "samsam": {
                   "version": "1.1.3",
-                  "from": "samsam@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz"
+                  "from": "samsam@~1.1"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.3 <1.0.0",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "from": "util@>=0.10.3 <1",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@2.0.1"
                 }
               }
             }
@@ -1360,566 +1354,125 @@
         }
       }
     },
-    "request": {
-      "version": "2.33.0",
-      "from": "request@2.33.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
-      "dependencies": {
-        "qs": {
-          "version": "0.6.6",
-          "from": "qs@0.6.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "from": "forever-agent@0.5.2",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "from": "node-uuid@1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
-        },
-        "mime": {
-          "version": "1.2.11",
-          "from": "mime@1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "from": "punycode@1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            }
-          }
-        },
-        "form-data": {
-          "version": "0.1.4",
-          "from": "form-data@0.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-          "dependencies": {
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@0.0.7",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "async": {
-              "version": "0.9.2",
-              "from": "async@0.9.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.3.0",
-          "from": "tunnel-agent@0.3.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@0.10.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "asn1": {
-              "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "ctype@0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.3.0",
-          "from": "oauth-sign@0.3.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
-        },
-        "hawk": {
-          "version": "1.0.0",
-          "from": "hawk@1.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-          "dependencies": {
-            "hoek": {
-              "version": "0.9.1",
-              "from": "hoek@0.9.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-            },
-            "boom": {
-              "version": "0.4.2",
-              "from": "boom@0.4.2",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-            },
-            "cryptiles": {
-              "version": "0.2.2",
-              "from": "cryptiles@0.2.2",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-            },
-            "sntp": {
-              "version": "0.2.4",
-              "from": "sntp@0.2.4",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-            }
-          }
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-        }
-      }
+    "redis": {
+      "version": "0.10.3",
+      "from": "redis@~0.10.1"
     },
-    "requestretry": {
-      "version": "1.12.0",
-      "from": "requestretry@1.12.0",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.12.0.tgz",
-      "dependencies": {
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "from": "aws4@1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "2.1.2",
-              "from": "form-data@2.1.2",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "from": "asynckit@0.4.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "from": "har-validator@4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.5",
-                  "from": "ajv@4.11.5",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "from": "json-stable-stringify@1.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "from": "jsonify@0.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "from": "har-schema@1.0.5",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "from": "jsprim@1.4.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.11.0",
-                  "from": "sshpk@1.11.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "getpass": {
-                      "version": "0.1.6",
-                      "from": "getpass@0.1.6",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "from": "mime-types@2.1.15",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.27.0",
-                  "from": "mime-db@1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "from": "performance-now@0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "from": "safe-buffer@5.0.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "from": "tough-cookie@2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "from": "punycode@1.4.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "from": "uuid@3.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-            }
-          }
-        },
-        "when": {
-          "version": "3.7.8",
-          "from": "when@3.7.8",
-          "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
-        }
-      }
+    "underscore": {
+      "version": "1.7.0",
+      "from": "underscore@~1.7.0"
+    },
+    "mongo-uri": {
+      "version": "0.1.2",
+      "from": "mongo-uri@^0.1.2"
     },
     "s3-streams": {
       "version": "0.3.0",
-      "from": "s3-streams@0.3.0",
-      "resolved": "https://registry.npmjs.org/s3-streams/-/s3-streams-0.3.0.tgz",
+      "from": "s3-streams@^0.3.0",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "from": "lodash@^3.9.3"
         },
         "readable-stream": {
           "version": "2.2.6",
-          "from": "readable-stream@2.2.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+          "from": "readable-stream@^2.0.0",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+              "from": "buffer-shims@^1.0.0"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+              "from": "core-util-is@~1.0.0"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "from": "isarray@~1.0.0"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "from": "inherits@~2.0.1"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+              "from": "process-nextick-args@~1.0.6"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "from": "string_decoder@~0.10.x"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+              "from": "util-deprecate@~1.0.1"
             }
           }
         },
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+          "from": "bluebird@^2.9.27"
         }
       }
     },
-    "settings-sharelatex": {
-      "version": "1.0.0",
-      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
-      "resolved": "git+https://github.com/sharelatex/settings-sharelatex.git#cbc5e41c1dbe6789721a14b3fdae05bf22546559",
+    "JSONStream": {
+      "version": "1.3.1",
+      "from": "JSONStream@^1.0.4",
       "dependencies": {
-        "coffee-script": {
-          "version": "1.6.0",
-          "from": "coffee-script@1.6.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz"
+        "jsonparse": {
+          "version": "1.3.0",
+          "from": "jsonparse@^1.2.0"
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "through@>=2.2.7 <3"
         }
       }
     },
-    "underscore": {
-      "version": "1.7.0",
-      "from": "underscore@1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    "heap": {
+      "version": "0.2.6",
+      "from": "heap@^0.2.6"
     },
     "v8-profiler": {
       "version": "5.7.0",
-      "from": "v8-profiler@5.7.0",
-      "resolved": "https://registry.npmjs.org/v8-profiler/-/v8-profiler-5.7.0.tgz",
+      "from": "v8-profiler@^5.6.5",
       "dependencies": {
         "nan": {
           "version": "2.5.1",
-          "from": "nan@2.5.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
+          "from": "nan@^2.5.1"
         },
         "node-pre-gyp": {
           "version": "0.6.34",
-          "from": "node-pre-gyp@0.6.34",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz",
+          "from": "node-pre-gyp@^0.6.34",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@^0.5.1",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "from": "minimist@0.0.8"
                 }
               }
             },
             "nopt": {
               "version": "4.0.1",
-              "from": "nopt@4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "from": "nopt@^4.0.1",
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.0",
-                  "from": "abbrev@1.1.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                  "from": "abbrev@1"
                 },
                 "osenv": {
                   "version": "0.1.4",
-                  "from": "osenv@0.1.4",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                  "from": "osenv@^0.1.4",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.2",
-                      "from": "os-homedir@1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                      "from": "os-homedir@^1.0.0"
                     },
                     "os-tmpdir": {
                       "version": "1.0.2",
-                      "from": "os-tmpdir@1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                      "from": "os-tmpdir@^1.0.0"
                     }
                   }
                 }
@@ -1927,58 +1480,47 @@
             },
             "npmlog": {
               "version": "4.0.2",
-              "from": "npmlog@4.0.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+              "from": "npmlog@^4.0.2",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "from": "are-we-there-yet@1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "from": "are-we-there-yet@~1.1.2",
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "from": "delegates@1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                      "from": "delegates@^1.0.0"
                     },
                     "readable-stream": {
                       "version": "2.2.6",
-                      "from": "readable-stream@2.2.6",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+                      "from": "readable-stream@^2.0.0 || ^1.1.13",
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
-                          "from": "buffer-shims@1.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                          "from": "buffer-shims@^1.0.0"
                         },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "from": "core-util-is@~1.0.0"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                          "from": "isarray@~1.0.0"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                          "from": "inherits@~2.0.1"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "process-nextick-args@1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                          "from": "process-nextick-args@~1.0.6"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "from": "string_decoder@~0.10.x"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "from": "util-deprecate@~1.0.1"
                         }
                       }
                     }
@@ -1986,53 +1528,43 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "from": "console-control-strings@1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                  "from": "console-control-strings@~1.1.0"
                 },
                 "gauge": {
                   "version": "2.7.3",
-                  "from": "gauge@2.7.3",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+                  "from": "gauge@~2.7.1",
                   "dependencies": {
                     "aproba": {
                       "version": "1.1.1",
-                      "from": "aproba@1.1.1",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                      "from": "aproba@^1.0.3"
                     },
                     "has-unicode": {
                       "version": "2.0.1",
-                      "from": "has-unicode@2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                      "from": "has-unicode@^2.0.0"
                     },
                     "object-assign": {
                       "version": "4.1.1",
-                      "from": "object-assign@4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                      "from": "object-assign@^4.1.0"
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "from": "signal-exit@3.0.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                      "from": "signal-exit@^3.0.0"
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "from": "string-width@1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "from": "string-width@^1.0.1",
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "from": "code-point-at@1.1.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                          "from": "code-point-at@^1.0.0"
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "from": "is-fullwidth-code-point@1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "from": "is-fullwidth-code-point@^1.0.0",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "from": "number-is-nan@1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                              "from": "number-is-nan@^1.0.0"
                             }
                           }
                         }
@@ -2040,135 +1572,112 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "from": "strip-ansi@^3.0.1",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "from": "ansi-regex@2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                          "from": "ansi-regex@^2.0.0"
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "from": "wide-align@1.1.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                      "from": "wide-align@^1.1.0"
                     }
                   }
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "from": "set-blocking@2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                  "from": "set-blocking@~2.0.0"
                 }
               }
             },
             "rc": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "from": "rc@^1.1.7",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
-                  "from": "deep-extend@0.4.1",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                  "from": "deep-extend@~0.4.0"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                  "from": "ini@~1.3.0"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                  "from": "minimist@^1.2.0"
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
-                  "from": "strip-json-comments@2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+                  "from": "strip-json-comments@~2.0.1"
                 }
               }
             },
             "request": {
               "version": "2.81.0",
-              "from": "request@2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "from": "request@^2.81.0",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "from": "aws-sign2@0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                  "from": "aws-sign2@~0.6.0"
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "from": "aws4@1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                  "from": "aws4@^1.2.1"
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "from": "caseless@0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                  "from": "caseless@~0.12.0"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "from": "combined-stream@~1.0.5",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                      "from": "delayed-stream@~1.0.0"
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                  "from": "extend@~3.0.0"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                  "from": "forever-agent@~0.6.1"
                 },
                 "form-data": {
                   "version": "2.1.2",
-                  "from": "form-data@2.1.2",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+                  "from": "form-data@~2.1.1",
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "from": "asynckit@0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                      "from": "asynckit@^0.4.0"
                     }
                   }
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "from": "har-validator@4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "from": "har-validator@~4.2.1",
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.5",
-                      "from": "ajv@4.11.5",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+                      "from": "ajv@^4.9.1",
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "from": "co@4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                          "from": "co@^4.6.0"
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "from": "json-stable-stringify@1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "from": "json-stable-stringify@^1.0.1",
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "from": "jsonify@0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                              "from": "jsonify@~0.0.0"
                             }
                           }
                         }
@@ -2176,124 +1685,101 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "from": "har-schema@1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                      "from": "har-schema@^1.0.5"
                     }
                   }
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "from": "hawk@3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "from": "hawk@~3.1.3",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                      "from": "hoek@2.x.x"
                     },
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                      "from": "boom@2.x.x"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                      "from": "cryptiles@2.x.x"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "from": "sntp@1.x.x"
                     }
                   }
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "from": "http-signature@1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "from": "http-signature@~1.1.0",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "from": "assert-plus@0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                      "from": "assert-plus@^0.2.0"
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "from": "jsprim@1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "from": "jsprim@^1.2.2",
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                          "from": "assert-plus@1.0.0"
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                          "from": "extsprintf@1.0.2"
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "from": "json-schema@0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                          "from": "json-schema@0.2.3"
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "from": "verror@1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                          "from": "verror@1.3.6"
                         }
                       }
                     },
                     "sshpk": {
                       "version": "1.11.0",
-                      "from": "sshpk@1.11.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+                      "from": "sshpk@^1.7.0",
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "from": "asn1@0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                          "from": "asn1@~0.2.3"
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                          "from": "assert-plus@^1.0.0"
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "from": "dashdash@1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                          "from": "dashdash@^1.12.0"
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "from": "getpass@0.1.6",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                          "from": "getpass@^0.1.1"
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "from": "jsbn@0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                          "from": "jsbn@~0.1.0"
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "from": "tweetnacl@0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                          "from": "tweetnacl@~0.14.0"
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "from": "jodid25519@1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                          "from": "jodid25519@^1.0.0"
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "from": "ecc-jsbn@0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                          "from": "ecc-jsbn@~0.1.1"
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "from": "bcrypt-pbkdf@1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                          "from": "bcrypt-pbkdf@^1.0.0"
                         }
                       }
                     }
@@ -2301,131 +1787,107 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "from": "is-typedarray@1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                  "from": "is-typedarray@~1.0.0"
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                  "from": "isstream@~0.1.2"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "from": "json-stringify-safe@~5.0.1"
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "from": "mime-types@2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "from": "mime-types@~2.1.7",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "from": "mime-db@1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                      "from": "mime-db@~1.27.0"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "from": "oauth-sign@0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                  "from": "oauth-sign@~0.8.1"
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "from": "performance-now@0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                  "from": "performance-now@^0.2.0"
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "from": "qs@6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                  "from": "qs@~6.4.0"
                 },
                 "safe-buffer": {
                   "version": "5.0.1",
-                  "from": "safe-buffer@5.0.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                  "from": "safe-buffer@^5.0.1"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                  "from": "stringstream@~0.0.4"
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "from": "tough-cookie@2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "from": "tough-cookie@~2.3.0",
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "from": "punycode@1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                      "from": "punycode@^1.4.1"
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "from": "tunnel-agent@0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                  "from": "tunnel-agent@^0.6.0"
                 },
                 "uuid": {
                   "version": "3.0.1",
-                  "from": "uuid@3.0.1",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                  "from": "uuid@^3.0.0"
                 }
               }
             },
             "rimraf": {
               "version": "2.6.1",
-              "from": "rimraf@2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "from": "rimraf@^2.6.1",
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
-                  "from": "glob@7.1.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "from": "glob@^7.0.5",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "fs.realpath@1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                      "from": "fs.realpath@^1.0.0"
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "from": "inflight@1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "from": "inflight@^1.0.4",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                          "from": "wrappy@1"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "from": "inherits@2"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "minimatch@3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "from": "minimatch@^3.0.2",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "brace-expansion@1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "from": "brace-expansion@^1.0.0",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                              "from": "balanced-match@^0.4.1"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "from": "concat-map@0.0.1"
                             }
                           }
                         }
@@ -2433,20 +1895,17 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "once@1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "from": "once@^1.3.0",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                          "from": "wrappy@1"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "path-is-absolute@1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                      "from": "path-is-absolute@^1.0.0"
                     }
                   }
                 }
@@ -2454,101 +1913,83 @@
             },
             "semver": {
               "version": "5.3.0",
-              "from": "semver@5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+              "from": "semver@^5.3.0"
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "from": "tar@^2.2.1",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "from": "block-stream@0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                  "from": "block-stream@*"
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "from": "fstream@1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                  "from": "fstream@^1.0.2",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "from": "graceful-fs@4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                      "from": "graceful-fs@^4.1.2"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "from": "inherits@2"
                 }
               }
             },
             "tar-pack": {
               "version": "3.4.0",
-              "from": "tar-pack@3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "from": "tar-pack@^3.4.0",
               "dependencies": {
                 "debug": {
                   "version": "2.6.3",
-                  "from": "debug@2.6.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+                  "from": "debug@^2.2.0",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.2",
-                      "from": "ms@0.7.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                      "from": "ms@0.7.2"
                     }
                   }
                 },
                 "fstream": {
                   "version": "1.0.11",
-                  "from": "fstream@1.0.11",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                  "from": "fstream@^1.0.10",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "from": "graceful-fs@4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                      "from": "graceful-fs@^4.1.2"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "from": "inherits@2"
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "from": "fstream-ignore@1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "from": "fstream-ignore@^1.0.5",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "from": "inherits@2"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "minimatch@3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "from": "minimatch@^3.0.0",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "brace-expansion@1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "from": "brace-expansion@^1.0.0",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                              "from": "balanced-match@^0.4.1"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "from": "concat-map@0.0.1"
                             }
                           }
                         }
@@ -2558,64 +1999,122 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "once@1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "from": "once@^1.3.3",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                      "from": "wrappy@1"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "2.2.6",
-                  "from": "readable-stream@2.2.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+                  "from": "readable-stream@^2.1.4",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "buffer-shims@1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                      "from": "buffer-shims@^1.0.0"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "from": "core-util-is@~1.0.0"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                      "from": "isarray@~1.0.0"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "from": "inherits@~2.0.1"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                      "from": "process-nextick-args@~1.0.6"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "from": "string_decoder@~0.10.x"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "from": "util-deprecate@~1.0.1"
                     }
                   }
                 },
                 "uid-number": {
                   "version": "0.0.6",
-                  "from": "uid-number@0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                  "from": "uid-number@^0.0.6"
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.37.0",
+      "from": "aws-sdk@^2.1.34",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.37.0.tgz",
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "from": "buffer@4.9.1",
+          "dependencies": {
+            "base64-js": {
+              "version": "1.2.0",
+              "from": "base64-js@^1.0.2"
+            },
+            "ieee754": {
+              "version": "1.1.8",
+              "from": "ieee754@^1.1.4"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@^1.0.0"
+            }
+          }
+        },
+        "crypto-browserify": {
+          "version": "1.0.9",
+          "from": "crypto-browserify@1.0.9"
+        },
+        "jmespath": {
+          "version": "0.15.0",
+          "from": "jmespath@0.15.0"
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "from": "querystring@0.2.0"
+        },
+        "sax": {
+          "version": "1.1.5",
+          "from": "sax@1.1.5"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@0.10.3",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2"
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.0.0",
+          "from": "uuid@3.0.0"
+        },
+        "xml2js": {
+          "version": "0.4.15",
+          "from": "xml2js@0.4.15"
+        },
+        "xmlbuilder": {
+          "version": "2.6.2",
+          "from": "xmlbuilder@2.6.2",
+          "dependencies": {
+            "lodash": {
+              "version": "3.5.0",
+              "from": "lodash@~3.5.0"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1025,24 +1025,29 @@
       }
     },
     "redis-sharelatex": {
-      "version": "0.0.9",
-      "from": "redis-sharelatex@~0.0.9",
+      "version": "1.0.0",
+      "from": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.0",
+      "resolved": "git+https://github.com/sharelatex/redis-sharelatex.git#0cd669a9ed73c0330e3b912fc9d9a42dae3c4fbd",
       "dependencies": {
         "chai": {
           "version": "1.9.1",
           "from": "chai@1.9.1",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-1.9.1.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "assertion-error@1.0.0"
+              "from": "assertion-error@1.0.0",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
               "from": "deep-eql@0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "type-detect@0.1.1"
+                  "from": "type-detect@0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
             }
@@ -1051,148 +1056,180 @@
         "coffee-script": {
           "version": "1.8.0",
           "from": "coffee-script@1.8.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@~0.3.5"
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
         },
         "grunt-contrib-coffee": {
           "version": "0.11.1",
-          "from": "grunt-contrib-coffee@^0.11.0",
+          "from": "grunt-contrib-coffee@0.11.1",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.11.1.tgz",
           "dependencies": {
             "coffee-script": {
               "version": "1.7.1",
-              "from": "coffee-script@~1.7.0",
+              "from": "coffee-script@>=1.7.0 <1.8.0",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.5"
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.0",
+              "from": "chalk@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0"
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@^1.0.0"
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0"
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0"
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0"
+                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "grunt-mocha-test": {
           "version": "0.12.0",
           "from": "grunt-mocha-test@0.12.0",
+          "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.0.tgz",
           "dependencies": {
             "hooker": {
               "version": "0.2.3",
-              "from": "hooker@~0.2.3"
+              "from": "hooker@>=0.2.3 <0.3.0",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "fs-extra": {
               "version": "0.11.1",
-              "from": "fs-extra@~0.11.1",
+              "from": "fs-extra@>=0.11.1 <0.12.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
               "dependencies": {
                 "ncp": {
                   "version": "0.6.0",
-                  "from": "ncp@^0.6.0"
+                  "from": "ncp@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@^0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8"
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "jsonfile": {
                   "version": "2.4.0",
-                  "from": "jsonfile@^2.0.0",
+                  "from": "jsonfile@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
-                      "from": "graceful-fs@^4.1.6"
+                      "from": "graceful-fs@>=4.1.6 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.6.1",
-                  "from": "rimraf@^2.2.8",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "7.1.1",
-                      "from": "glob@^7.0.5",
+                      "from": "glob@>=7.0.5 <8.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                       "dependencies": {
                         "fs.realpath": {
                           "version": "1.0.0",
-                          "from": "fs.realpath@^1.0.0"
+                          "from": "fs.realpath@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                         },
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@^1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@1"
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@2"
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@2 || 3",
+                          "from": "minimatch@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.6",
-                              "from": "brace-expansion@^1.0.0",
+                              "version": "1.1.7",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@^0.4.1"
+                                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1"
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -1200,17 +1237,20 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@^1.3.0",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@1"
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@^1.0.0"
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                         }
                       }
                     }
@@ -1220,75 +1260,145 @@
             }
           }
         },
+        "ioredis": {
+          "version": "2.5.0",
+          "from": "ioredis@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "3.5.0",
+              "from": "bluebird@>=3.3.4 <4.0.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+            },
+            "cluster-key-slot": {
+              "version": "1.0.8",
+              "from": "cluster-key-slot@>=1.0.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz"
+            },
+            "debug": {
+              "version": "2.6.6",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.3",
+                  "from": "ms@0.7.3",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+                }
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
+            },
+            "flexbuffer": {
+              "version": "0.0.6",
+              "from": "flexbuffer@0.0.6",
+              "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz"
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "from": "lodash@>=4.8.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            },
+            "redis-commands": {
+              "version": "1.3.1",
+              "from": "redis-commands@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+            },
+            "redis-parser": {
+              "version": "1.3.0",
+              "from": "redis-parser@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz"
+            }
+          }
+        },
         "mocha": {
           "version": "1.21.4",
           "from": "mocha@1.21.4",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.4.tgz",
           "dependencies": {
             "commander": {
               "version": "2.0.0",
-              "from": "commander@2.0.0"
+              "from": "commander@2.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
             },
             "growl": {
               "version": "1.8.1",
-              "from": "growl@1.8.x"
+              "from": "growl@>=1.8.0 <1.9.0",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
             },
             "jade": {
               "version": "0.26.3",
               "from": "jade@0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
               "dependencies": {
                 "commander": {
                   "version": "0.6.1",
-                  "from": "commander@0.6.1"
+                  "from": "commander@0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.0",
-                  "from": "mkdirp@0.3.0"
+                  "from": "mkdirp@0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                 }
               }
             },
             "diff": {
               "version": "1.0.7",
-              "from": "diff@1.0.7"
+              "from": "diff@1.0.7",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
             },
             "debug": {
-              "version": "2.6.3",
+              "version": "2.6.6",
               "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.2",
-                  "from": "ms@0.7.2"
+                  "version": "0.7.3",
+                  "from": "ms@0.7.3",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@0.3.5"
+              "from": "mkdirp@0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "glob": {
               "version": "3.2.3",
               "from": "glob@3.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0"
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@2"
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             }
@@ -1296,57 +1406,69 @@
         },
         "redis": {
           "version": "0.12.1",
-          "from": "redis@0.12.1"
+          "from": "redis@0.12.1",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-0.12.1.tgz"
         },
         "redis-sentinel": {
           "version": "0.1.1",
           "from": "redis-sentinel@0.1.1",
+          "resolved": "https://registry.npmjs.org/redis-sentinel/-/redis-sentinel-0.1.1.tgz",
           "dependencies": {
             "redis": {
               "version": "0.11.0",
-              "from": "redis@0.11.x"
+              "from": "redis@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.11.0.tgz"
             },
             "q": {
               "version": "0.9.2",
-              "from": "q@0.9.2"
+              "from": "q@0.9.2",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.2.tgz"
             }
           }
         },
         "sandboxed-module": {
           "version": "1.0.1",
           "from": "sandboxed-module@1.0.1",
+          "resolved": "https://registry.npmjs.org/sandboxed-module/-/sandboxed-module-1.0.1.tgz",
           "dependencies": {
             "require-like": {
               "version": "0.1.2",
-              "from": "require-like@0.1.2"
+              "from": "require-like@0.1.2",
+              "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@0.0.9"
+              "from": "stack-trace@0.0.9",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "sinon": {
           "version": "1.10.3",
           "from": "sinon@1.10.3",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
           "dependencies": {
             "formatio": {
               "version": "1.0.2",
-              "from": "formatio@~1.0",
+              "from": "formatio@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
               "dependencies": {
                 "samsam": {
                   "version": "1.1.3",
-                  "from": "samsam@~1.1"
+                  "from": "samsam@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.3 <1",
+              "from": "util@>=0.10.3 <1.0.0",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }


### PR DESCRIPTION
shrinkwrap update changed mongodb-core version, causing "no primary available" errors

have added redis-sharelatex manually into shrinkwrap file to avoid changing any other versions