### PR TITLE
update to redis-sharelatex v1.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1025,9 +1025,9 @@
       }
     },
     "redis-sharelatex": {
-      "version": "1.0.1",
-      "from": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.1",
-      "resolved": "git+https://github.com/sharelatex/redis-sharelatex.git#0c581688a2077346ab79b67f1f6086a002e4dc17",
+      "version": "1.0.2",
+      "from": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.2",
+      "resolved": "git+https://github.com/sharelatex/redis-sharelatex.git#143b7eb192675f36d835080e534a4ac4899f918a",
       "dependencies": {
         "async": {
           "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
     "request": "~2.33.0",
     "requestretry": "^1.12.0",
-    "redis-sharelatex": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.1",
+    "redis-sharelatex": "git+https://github.com/sharelatex/redis-sharelatex.git#v1.0.2",
     "redis": "~0.10.1",
     "underscore": "~1.7.0",
     "mongo-uri": "^0.1.2",


### PR DESCRIPTION
updated shrinkwrap file entry for redis-sharelatex manually to avoid breaking other versions