### PR TITLE
Provide hosts as environment settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -3,31 +3,31 @@ TMP_DIR = Path.resolve(Path.join(__dirname, "../../", "tmp"))
 
 module.exports =
 	mongo:
-		url: 'mongodb://127.0.0.1/sharelatex'
+		url: "mongodb://#{process.env["MONGO_HOST"] or "localhost"}/sharelatex"
 	internal:
 		trackchanges:
 			port: 3015
-			host: "localhost"
+			host: process.env["LISTEN_ADDRESS"] or "localhost"
 	apis:
 		documentupdater:
-			url: "http://localhost:3003"
+			url: "http://#{process.env["DOCUPDATER_HOST"] or "localhost"}:3003"
 		docstore:
-			url: "http://localhost:3016"
+			url: "http://#{process.env["DOCSTORE_HOST"] or "localhost"}:3016"
 		web:
-			url: "http://localhost:3000"
+			url: "http://#{process.env["WEB_HOST"] or "localhost"}:3000"
 			user: "sharelatex"
 			pass: "password"
 	redis:
 		lock:
-			host: "localhost"
+			host: process.env["REDIS_HOST"] or "localhost"
 			port: 6379
 			pass: ""
 			key_schema:
 				historyLock: ({doc_id}) -> "HistoryLock:#{doc_id}"
 				historyIndexLock: ({project_id}) -> "HistoryIndexLock:#{project_id}"
 		history:
-			port:"6379"
-			host:"localhost"
+			port: "6379"
+			host: process.env["REDIS_HOST"] or "localhost"
 			password:""
 			key_schema:
 				uncompressedHistoryOps: ({doc_id}) -> "UncompressedHistoryOps:#{doc_id}"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/track-changes-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "JSONStream": "^1.0.4",
     "async": "~0.2.10",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.