### PR TITLE
add missing coffeescript to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "chai": "~4.1.1",
+    "coffee-script": "^1.7.1",
     "sinon": "~3.2.1",
     "sandboxed-module": "~0.3.0",
     "grunt-execute": "~0.1.5",


### PR DESCRIPTION
using the same version as in web

not needed to get the tests to pass but maybe we should include it